### PR TITLE
fix: daemon task resume via branch convention and discovery reorder

### DIFF
--- a/src/daemon/runtime.rs
+++ b/src/daemon/runtime.rs
@@ -987,6 +987,31 @@ async fn dispatch_task(
         spawn_blocking_op(move || worktree::clean_worktree(&wt)).await?;
     }
 
+    // Remote-first project branch sync — must run BEFORE discovery so that
+    // `ralph/issue-{n}` (which contains committed project data) is checked
+    // out when we scan `.ralph/projects/`.
+    {
+        let wt = wt_path.clone();
+        let base_branch = config.base_branch.clone();
+        match spawn_blocking_op(move || {
+            crate::git::branch::sync_project_branch(&wt, issue_number, &base_branch)
+        })
+        .await
+        {
+            Ok(()) => {
+                eprintln!(
+                    "dispatch: remote-first sync completed for issue {issue_number} (task {task_id})"
+                );
+            }
+            Err(err) => {
+                eprintln!(
+                    "dispatch: remote-first sync failed for issue {issue_number} (task {task_id}): {err}"
+                );
+                return Err(err);
+            }
+        }
+    }
+
     // Dispatch-time project discovery.
     // Short-circuit if the worktree was already on a project branch (resume).
     let effective_project_id = if let Some(project_id) = prior_project_id {
@@ -1030,29 +1055,6 @@ async fn dispatch_task(
             }
         }
     };
-
-    // Remote-first project branch sync
-    {
-        let wt = wt_path.clone();
-        let base_branch = config.base_branch.clone();
-        match spawn_blocking_op(move || {
-            crate::git::branch::sync_project_branch(&wt, issue_number, &base_branch)
-        })
-        .await
-        {
-            Ok(()) => {
-                eprintln!(
-                    "dispatch: remote-first sync completed for issue {issue_number} (task {task_id})"
-                );
-            }
-            Err(err) => {
-                eprintln!(
-                    "dispatch: remote-first sync failed for issue {issue_number} (task {task_id}): {err}"
-                );
-                return Err(err);
-            }
-        }
-    }
 
     // Checkout project branch if resuming
     if let Some(ref project_id) = effective_project_id {


### PR DESCRIPTION
## Summary

- **Capture prior project branch on restart**: `create_worktree()` now returns the project_id if the worktree was on a `ralph/{project_id}` branch before being reset to the daemon branch. This allows `dispatch_task()` to skip ambiguous discovery and resume directly.
- **Move sync before discovery**: `sync_project_branch()` now runs BEFORE `discover_project_ids()`, so the issue branch (`ralph/issue-{n}`) with committed project data is checked out when discovery scans `.ralph/projects/`.

These two changes fix the bug where daemon tasks always start from scratch after a restart instead of resuming.

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib` — 783 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)