### PR TITLE
fix: use false for gemini enabled field

### DIFF
--- a/.ralph/ralph.toml
+++ b/.ralph/ralph.toml
@@ -85,7 +85,7 @@ args = [
     "stream-json",
 ]
 timeout_seconds = 7200
-enabled = "disabled"
+enabled = false
 
 [backends.gemini.env]
 


### PR DESCRIPTION
Fix: `enabled = "disabled"` is not valid; must be `false`.