### PR TITLE
fix: give QuickPRD codebase awareness before drafting specs

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -799,6 +799,7 @@ pub struct BackendRegistry {
     invocation_context: SharedInvocationContext,
     config: GlobalConfig,
     tmux: BackendRegistryTmuxConfig,
+    cwd: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone)]
@@ -840,7 +841,14 @@ impl BackendRegistry {
             invocation_context: shared_invocation,
             config: config.clone(),
             tmux,
+            cwd: None,
         }
+    }
+
+    pub fn set_cwd(&mut self, cwd: Option<PathBuf>) {
+        self.cwd = cwd;
+        // Clear cached backends so they are re-created with the new cwd.
+        self.backends.clear();
     }
 
     /// Set the tmux execution context (loop number, role) for the next backend
@@ -1195,9 +1203,24 @@ impl BackendRegistry {
 
         let model = spec.model.as_deref();
         match spec.name.as_str() {
-            "claude" => Ok(claude::backend_from_config(&self.config, model, role, None)),
-            "codex" => Ok(codex::backend_from_config(&self.config, model, role, None)),
-            "gemini" => Ok(gemini::backend_from_config(&self.config, model, role, None)),
+            "claude" => Ok(claude::backend_from_config(
+                &self.config,
+                model,
+                role,
+                self.cwd.clone(),
+            )),
+            "codex" => Ok(codex::backend_from_config(
+                &self.config,
+                model,
+                role,
+                self.cwd.clone(),
+            )),
+            "gemini" => Ok(gemini::backend_from_config(
+                &self.config,
+                model,
+                role,
+                self.cwd.clone(),
+            )),
             _ => Err(RalphError::Validation(format!(
                 "unknown backend for spec lookup: {}",
                 backend_spec_key(spec)

--- a/src/cli/auto.rs
+++ b/src/cli/auto.rs
@@ -166,6 +166,7 @@ pub async fn execute(args: AutoArgs) -> Result<()> {
             window_keep_seconds: workspace.config.workspace.tmux_window_keep_seconds,
         },
     );
+    registry.set_cwd(Some(std::env::current_dir()?));
 
     backend_spec::validate_backend_spec(&writer_spec, &workspace.config)?;
     backend_spec::validate_backend_spec(&reviewer_spec, &workspace.config)?;

--- a/src/prd/quick.rs
+++ b/src/prd/quick.rs
@@ -81,6 +81,17 @@ pub const DRAFT_PROMPT: &str = r#"You are a senior software engineer writing a f
 **Feature Idea:**
 {{idea}}
 
+**Before writing the spec, explore the project:**
+1. List the directory tree to understand the project layout
+2. Read key files to understand architecture
+3. Search for existing utilities and patterns related to the feature
+4. Identify code that can be reused instead of building from scratch
+
+**Principles:**
+- Prefer reusing existing code over creating new abstractions
+- Keep changes minimal — the simplest solution that meets the requirement
+- Reference specific existing files/functions in Technical Approach
+
 **Required Output Format:**
 Your response must be a markdown document with the following exact section headings:
 
@@ -106,6 +117,11 @@ pub const REVIEW_PROMPT: &str = r#"You are a senior engineer reviewing an engine
 
 **Task:**
 Review the spec for: technical feasibility, missing edge cases, completeness of acceptance criteria, testing coverage, and clarity.
+
+Check specifically:
+- Does the spec reuse existing project infrastructure where possible?
+- Does it avoid reinventing utilities that already exist in the codebase?
+- Is the solution the simplest approach that meets the requirements?
 
 **Required Output Format:**
 Your response MUST be a single fenced JSON block:


### PR DESCRIPTION
## Summary
- **Pass `cwd` through `BackendRegistry`** so QuickPRD backends run inside the repo directory and can explore the codebase
- **Update `DRAFT_PROMPT`** to instruct the writer to explore the project structure, find existing utilities, and prefer reuse over new abstractions
- **Update `REVIEW_PROMPT`** to check specs for unnecessary complexity and missed reuse of existing infrastructure

## Motivation
QuickPRD was generating specs completely blind to the codebase, causing it to reinvent existing infrastructure (e.g., designing custom logging when `LogWriter` already exists). This led to over-engineered specs taking 13+ loops to implement instead of 1-2.

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib` — 791 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)