### PR TITLE
fix: detect codex quota errors reported via stdout JSON

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -679,9 +679,19 @@ impl CliBackend {
                 let stderr_bytes = self.collect_stderr(stderr_handle).await?;
 
                 if !status.success() {
+                    let stderr_text =
+                        String::from_utf8_lossy(&stderr_bytes).trim().to_owned();
+                    // Some backends (e.g. codex) report errors via stdout JSON
+                    // rather than stderr. When stderr is empty, include stdout
+                    // so quota/error messages are visible to callers.
+                    let details = if stderr_text.is_empty() {
+                        String::from_utf8_lossy(&captured_stdout).trim().to_owned()
+                    } else {
+                        stderr_text
+                    };
                     return Err(RalphError::BackendCommandFailed {
                         backend: self.name.clone(),
-                        details: String::from_utf8_lossy(&stderr_bytes).trim().to_owned(),
+                        details,
                     });
                 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -144,6 +144,7 @@ impl RalphError {
                     || details.contains("RESOURCE_EXHAUSTED")
                     || details.contains("MODEL_CAPACITY_EXHAUSTED")
                     || details.contains("quota will reset")
+                    || details.contains("hit your usage limit")
             }
             _ => false,
         }


### PR DESCRIPTION
## Summary
- When codex exits non-zero with empty stderr, fall back to stdout content for error details (codex reports errors via stdout JSON, not stderr)
- Add codex's `"hit your usage limit"` pattern to `is_quota_error()` so the orchestrator skips the backend gracefully instead of aborting the entire run

## Root Cause
Codex reports quota errors in its stdout JSON stream (`{"type":"error","message":"You've hit your usage limit..."}`), but the error path at `mod.rs:682` only captured stderr. With empty stderr, `BackendCommandFailed.details` was `""`, making `is_quota_error()` return false, causing the orchestrator to abort instead of skipping the exhausted backend.

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib` — 791 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)