### PR TITLE
fix: default to claude when artifact backend frontmatter is missing

### DIFF
--- a/src/project/lifecycle.rs
+++ b/src/project/lifecycle.rs
@@ -605,9 +605,12 @@ fn reconstruct_feature_loop(
         .and_then(|artifact| first_feature_name(&artifact.body))
         .unwrap_or_else(|| loop_slug.replace('-', " "));
 
+    // When backend frontmatter is missing from artifacts, default to "claude"
+    // rather than "unknown" which is not a valid backend name and would cause
+    // resolution failures on resume.
     let planner_backend = spec
         .and_then(|artifact| artifact.frontmatter.get("backend").cloned())
-        .unwrap_or_else(|| "unknown".to_owned());
+        .unwrap_or_else(|| "claude".to_owned());
     let implementer_backend = impl_notes
         .and_then(|artifact| artifact.frontmatter.get("backend").cloned())
         .or_else(|| {
@@ -620,7 +623,7 @@ fn reconstruct_feature_loop(
                 })
                 .and_then(|artifact| artifact.frontmatter.get("backend").cloned())
         })
-        .unwrap_or_else(|| "unknown".to_owned());
+        .unwrap_or_else(|| "claude".to_owned());
     let reviewer_backend = approval
         .and_then(|artifact| artifact.frontmatter.get("backend").cloned())
         .or_else(|| {
@@ -630,13 +633,13 @@ fn reconstruct_feature_loop(
                 .find(|artifact| artifact.base_name.starts_with("review-"))
                 .and_then(|artifact| artifact.frontmatter.get("backend").cloned())
         })
-        .unwrap_or_else(|| "unknown".to_owned());
+        .unwrap_or_else(|| "claude".to_owned());
     let qa_backend = artifacts
         .iter()
         .rev()
         .find(|artifact| artifact.base_name.starts_with("qa-"))
         .and_then(|artifact| artifact.frontmatter.get("backend").cloned())
-        .unwrap_or_else(|| "unknown".to_owned());
+        .unwrap_or_else(|| "claude".to_owned());
 
     let completed_at = approval.map(|artifact| artifact.observed_at);
     let status = if completed_at.is_some() {
@@ -736,7 +739,7 @@ fn reconstruct_completion_attempt(
                     .frontmatter
                     .get("backend")
                     .cloned()
-                    .unwrap_or_else(|| "unknown".to_owned());
+                    .unwrap_or_else(|| "claude".to_owned());
                 completers.push(backend);
                 if let Some(pv) = parse_completion_verdict(&v.body) {
                     any_verdict = true;
@@ -772,7 +775,7 @@ fn reconstruct_completion_attempt(
                 .frontmatter
                 .get("backend")
                 .cloned()
-                .unwrap_or_else(|| "unknown".to_owned());
+                .unwrap_or_else(|| "claude".to_owned());
             let verdict = parse_completion_verdict(&single.body);
             (vec![backend], Some(single), verdict)
         } else {
@@ -789,7 +792,7 @@ fn reconstruct_completion_attempt(
                     .frontmatter
                     .get("backend")
                     .cloned()
-                    .unwrap_or_else(|| "unknown".to_owned()),
+                    .unwrap_or_else(|| "claude".to_owned()),
                 passed: true,
                 artifact: artifact.rel_path.clone(),
             });
@@ -804,7 +807,7 @@ fn reconstruct_completion_attempt(
                     .frontmatter
                     .get("backend")
                     .cloned()
-                    .unwrap_or_else(|| "unknown".to_owned()),
+                    .unwrap_or_else(|| "claude".to_owned()),
                 passed: false,
                 artifact: artifact.rel_path.clone(),
             });
@@ -824,7 +827,7 @@ fn reconstruct_completion_attempt(
 
     let planner_backend = termination
         .and_then(|artifact| artifact.frontmatter.get("backend").cloned())
-        .unwrap_or_else(|| "unknown".to_owned());
+        .unwrap_or_else(|| "claude".to_owned());
 
     CompletionLoopState {
         loop_number,


### PR DESCRIPTION
## Summary
- When resuming a project, `reconstruct_feature_loop()` and `reconstruct_completion_loop()` defaulted to `"unknown"` as backend name when artifact frontmatter lacked a `backend` field
- This caused `"unknown backend for spec lookup: unknown"` errors on resume
- Changed all fallbacks from `"unknown"` to `"claude"` (the system default backend)

## Test plan
- [x] `cargo check` passes
- [ ] Resume issue-115 which was hitting this exact error

🤖 Generated with [Claude Code](https://claude.com/claude-code)