### PR TITLE
config: disable codex, enable openrouter with codex models

### DIFF
--- a/.ralph/ralph.toml
+++ b/.ralph/ralph.toml
@@ -59,7 +59,7 @@ args = [
     "-",
 ]
 timeout_seconds = 7200
-enabled = "auto"
+enabled = false
 
 [backends.codex.env]
 


### PR DESCRIPTION
## Summary
- Disable codex backend (quota exhausted until Mar 3rd)
- Enable openrouter backend with codex-high models via OpenRouter API

🤖 Generated with [Claude Code](https://claude.com/claude-code)