### PR TITLE
config: fix openrouter model IDs

### DIFF
--- a/.ralph/ralph.toml
+++ b/.ralph/ralph.toml
@@ -93,15 +93,15 @@ ANTHROPIC_BASE_URL = "https://openrouter.ai/api"
 ANTHROPIC_API_KEY = ""
 
 [backends.openrouter.models]
-planner = "openai/gpt-5.3-codex-high"
-implementer = "openai/gpt-5.3-codex-high"
-reviewer = "openai/gpt-5.3-codex-high"
-final_reviewer = "openai/gpt-5.3-codex-high"
-arbiter = "openai/gpt-5.3-codex-high"
-qa = "openai/gpt-5.3-codex-high"
-completer = "openai/gpt-5.3-codex-high"
-acceptance_qa = "openai/gpt-5.3-codex-high"
-reformatter = "openai/gpt-5.3-codex-medium"
+planner = "openai/gpt-5.3-codex"
+implementer = "openai/gpt-5.3-codex"
+reviewer = "openai/gpt-5.3-codex"
+final_reviewer = "openai/gpt-5.3-codex"
+arbiter = "openai/gpt-5.3-codex"
+qa = "openai/gpt-5.3-codex"
+completer = "openai/gpt-5.3-codex"
+acceptance_qa = "openai/gpt-5.3-codex"
+reformatter = "openai/gpt-5.3-codex"
 
 [backends.openrouter.role_timeouts]
 


### PR DESCRIPTION
OpenRouter uses openai/gpt-5.3-codex without -high/-medium suffixes