### PR TITLE
feat: switch openrouter backend to opencode CLI

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -227,7 +227,7 @@ impl CliBackend {
             Some(id) => match self.name.as_str() {
                 n if n.starts_with("claude") || n == "claude" => self.effective_args_claude(id),
                 n if n.starts_with("openrouter") || n == "openrouter" => {
-                    self.effective_args_claude(id)
+                    self.effective_args_opencode(id)
                 }
                 n if n.starts_with("codex") || n == "codex" => self.effective_args_codex(id),
                 n if n.starts_with("gemini") || n == "gemini" => self.effective_args_gemini(id),
@@ -243,11 +243,7 @@ impl CliBackend {
     /// For Codex: adds --json.
     fn ensure_json_output_args(&self) -> Result<Vec<String>> {
         match self.name.as_str() {
-            n if n.starts_with("claude")
-                || n == "claude"
-                || n.starts_with("openrouter")
-                || n == "openrouter" =>
-            {
+            n if n.starts_with("claude") || n == "claude" => {
                 let mut args = self.args.clone();
                 // Only add if not already present
                 if !args
@@ -290,6 +286,27 @@ impl CliBackend {
                     args.push(arg.clone());
                 }
                 args.push("--output-format".to_owned());
+                args.push("json".to_owned());
+                Ok(args)
+            }
+            n if n.starts_with("openrouter") || n == "openrouter" => {
+                let mut args = Vec::with_capacity(self.args.len() + 2);
+                let mut skip_next = false;
+                for arg in &self.args {
+                    if skip_next {
+                        skip_next = false;
+                        continue;
+                    }
+                    if arg == "--format" {
+                        skip_next = true;
+                        continue;
+                    }
+                    if arg.starts_with("--format=") {
+                        continue;
+                    }
+                    args.push(arg.clone());
+                }
+                args.push("--format".to_owned());
                 args.push("json".to_owned());
                 Ok(args)
             }
@@ -438,6 +455,36 @@ impl CliBackend {
         result.push("--resume".to_owned());
         result.push(session_id.to_owned());
         result.push("--output-format".to_owned());
+        result.push("json".to_owned());
+        Ok(result)
+    }
+
+    fn effective_args_opencode(&self, session_id: &str) -> Result<Vec<String>> {
+        // OpenCode resume rules:
+        // 1. Keep all existing args.
+        // 2. Remove existing --session and --format forms.
+        // 3. Add --session <id> and --format json.
+        let mut result = Vec::new();
+        let mut skip_next = false;
+
+        for arg in self.args.iter() {
+            if skip_next {
+                skip_next = false;
+                continue;
+            }
+            if arg == "--session" || arg == "-s" || arg == "--format" || arg == "-f" {
+                skip_next = true;
+                continue;
+            }
+            if arg.starts_with("--session=") || arg.starts_with("--format=") {
+                continue;
+            }
+            result.push(arg.clone());
+        }
+
+        result.push("--session".to_owned());
+        result.push(session_id.to_owned());
+        result.push("--format".to_owned());
         result.push("json".to_owned());
         Ok(result)
     }
@@ -970,10 +1017,8 @@ impl BackendRegistry {
         };
         // If the primary opposite is unavailable, try openrouter as substitute
         // for codex (since openrouter provides codex-equivalent models).
-        if !self.is_backend_available(primary) && primary == "codex" {
-            if self.is_backend_available("openrouter") {
-                return Ok("openrouter");
-            }
+        if !self.is_backend_available(primary) && primary == "codex" && self.is_backend_available("openrouter") {
+            return Ok("openrouter");
         }
         Ok(primary)
     }
@@ -2280,7 +2325,7 @@ done
             .expect("should assign backends");
         assert_eq!(backends.planner, "claude(opus)");
         assert!(
-            backends.implementer.starts_with("openrouter("),
+            backends.implementer == "openrouter" || backends.implementer.starts_with("openrouter("),
             "implementer should be openrouter, got: {}",
             backends.implementer
         );
@@ -2290,7 +2335,7 @@ done
             .assign_feature_backends(6, "claude", &no_overrides)
             .expect("should assign backends");
         assert!(
-            backends.planner.starts_with("openrouter("),
+            backends.planner == "openrouter" || backends.planner.starts_with("openrouter("),
             "planner should be openrouter, got: {}",
             backends.planner
         );

--- a/src/backend/openrouter.rs
+++ b/src/backend/openrouter.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use crate::backend::claude::effective_args_claude;
 use crate::backend::CliBackend;
 use crate::config::GlobalConfig;
 
@@ -12,8 +11,10 @@ pub fn backend_from_config(
     cwd: Option<PathBuf>,
 ) -> CliBackend {
     let backend = &config.backends.openrouter;
-    let args = effective_args_claude(&backend.args, model);
+    let mut args = backend.args.clone();
     let name = if let Some(model_name) = model {
+        // Inject -m <model> before the "run" subcommand.
+        args.splice(0..0, ["-m".to_owned(), model_name.to_owned()]);
         format!("openrouter({model_name})")
     } else {
         "openrouter".to_owned()
@@ -24,18 +25,6 @@ pub fn backend_from_config(
         None => Duration::from_secs(backend.timeout_seconds),
     };
 
-    let mut env = backend.env.clone();
-    // Always ensure OpenRouter API routing.
-    env.entry("ANTHROPIC_BASE_URL".to_owned())
-        .or_insert_with(|| "https://openrouter.ai/api".to_owned());
-    env.entry("ANTHROPIC_API_KEY".to_owned())
-        .or_default();
-    // If no explicit auth token in config, try OPENROUTER_API_KEY from env.
-    if !env.contains_key("ANTHROPIC_AUTH_TOKEN") {
-        if let Ok(key) = std::env::var("OPENROUTER_API_KEY") {
-            env.insert("ANTHROPIC_AUTH_TOKEN".to_owned(), key);
-        }
-    }
-
-    CliBackend::new(&name, backend.command.clone(), args, timeout, env).with_cwd(cwd)
+    CliBackend::new(&name, backend.command.clone(), args, timeout, backend.env.clone())
+        .with_cwd(cwd)
 }

--- a/src/backend/output_normalizer.rs
+++ b/src/backend/output_normalizer.rs
@@ -38,6 +38,8 @@ const STREAM_EVENT_TYPES: &[&str] = &[
     "message",
     "tool_use",
     "tool_result",
+    // OpenCode CLI
+    "step_start",
 ];
 
 pub fn normalize_output(raw: &str) -> Result<NormalizedOutput> {
@@ -262,6 +264,49 @@ pub fn normalize_claude_stream_json(raw: &str) -> Result<NormalizedOutput> {
                 merge_usage_from_event(&event, &mut output);
             }
             "turn.started" => {}
+
+            // --- OpenCode CLI events ---
+            "step_start" => {
+                if output.session_id.is_none() {
+                    output.session_id = event
+                        .get("sessionID")
+                        .and_then(Value::as_str)
+                        .map(str::to_owned);
+                }
+            }
+            "text" => {
+                if let Some(text) = event.pointer("/part/text").and_then(Value::as_str) {
+                    if !output.text.is_empty() && !output.text.ends_with('\n') {
+                        output.text.push('\n');
+                    }
+                    output.text.push_str(text);
+                }
+                if output.session_id.is_none() {
+                    output.session_id = event
+                        .get("sessionID")
+                        .and_then(Value::as_str)
+                        .map(str::to_owned);
+                }
+            }
+            "step_finish" => {
+                // Extract tokens from part.tokens: {input, output, reasoning, cache: {read, write}}
+                if let Some(tokens) = event.pointer("/part/tokens") {
+                    output.tokens_in =
+                        extract_u64(tokens, &["input"]).or(output.tokens_in);
+                    output.tokens_out =
+                        extract_u64(tokens, &["output"]).or(output.tokens_out);
+                    if let Some(cache) = tokens.get("cache") {
+                        output.cached_in =
+                            extract_u64(cache, &["read"]).or(output.cached_in);
+                    }
+                }
+                if output.session_id.is_none() {
+                    output.session_id = event
+                        .get("sessionID")
+                        .and_then(Value::as_str)
+                        .map(str::to_owned);
+                }
+            }
 
             _ => {}
         }
@@ -966,5 +1011,46 @@ Done."#;
             !normalized.text.contains("written to file"),
             "should not use the short summary result"
         );
+    }
+
+    // --- OpenCode CLI output ---
+
+    #[test]
+    fn normalize_output_opencode_cli_extracts_text_and_metadata() {
+        let raw = concat!(
+            r#"{"type":"step_start","timestamp":1772226736532,"sessionID":"ses_abc123","part":{"id":"prt_1","sessionID":"ses_abc123","messageID":"msg_1","type":"step-start","snapshot":"abc"}}"#,
+            "\n",
+            r#"{"type":"text","timestamp":1772226737081,"sessionID":"ses_abc123","part":{"id":"prt_2","sessionID":"ses_abc123","messageID":"msg_1","type":"text","text":"Hello from opencode!","time":{"start":1772226737080,"end":1772226737080}}}"#,
+            "\n",
+            r#"{"type":"step_finish","timestamp":1772226737089,"sessionID":"ses_abc123","part":{"id":"prt_3","sessionID":"ses_abc123","messageID":"msg_1","type":"step-finish","reason":"stop","snapshot":"abc","cost":0.001888,"tokens":{"input":248,"output":65,"reasoning":51,"cache":{"read":12220,"write":0}}}}"#,
+        );
+        let normalized = normalize_output(raw).expect("opencode cli");
+        assert_eq!(normalized.text, "Hello from opencode!");
+        assert_eq!(normalized.session_id.as_deref(), Some("ses_abc123"));
+        assert_eq!(normalized.tokens_in, Some(248));
+        assert_eq!(normalized.tokens_out, Some(65));
+        assert_eq!(normalized.cached_in, Some(12220));
+    }
+
+    #[test]
+    fn normalize_output_opencode_cli_multiple_text_events() {
+        let raw = concat!(
+            r#"{"type":"step_start","timestamp":1,"sessionID":"ses_multi","part":{"type":"step-start"}}"#,
+            "\n",
+            r#"{"type":"text","timestamp":2,"sessionID":"ses_multi","part":{"type":"text","text":"First part."}}"#,
+            "\n",
+            "{\"type\":\"text\",\"timestamp\":3,\"sessionID\":\"ses_multi\",\"part\":{\"type\":\"text\",\"text\":\"# Implementation Notes\\n\\nDone.\"}}",
+            "\n",
+            r#"{"type":"step_finish","timestamp":4,"sessionID":"ses_multi","part":{"type":"step-finish","tokens":{"input":100,"output":50}}}"#,
+        );
+        let normalized = normalize_output(raw).expect("opencode multi text");
+        assert!(
+            normalized.text.contains("\n# Implementation Notes"),
+            "H1 heading must be on its own line; got: {:?}",
+            normalized.text,
+        );
+        assert_eq!(normalized.session_id.as_deref(), Some("ses_multi"));
+        assert_eq!(normalized.tokens_in, Some(100));
+        assert_eq!(normalized.tokens_out, Some(50));
     }
 }

--- a/src/config/global.rs
+++ b/src/config/global.rs
@@ -803,34 +803,16 @@ fn default_gemini_backend_config() -> BackendConfig {
 
 fn default_openrouter_backend_config() -> BackendConfig {
     BackendConfig {
-        command: "claude".to_owned(),
+        command: "opencode".to_owned(),
         args: vec![
-            "-p".to_owned(),
-            "--permission-mode".to_owned(),
-            "acceptEdits".to_owned(),
-            "--allowedTools".to_owned(),
-            "Bash,Edit,Write,Read,Glob,Grep,WebSearch,WebFetch,Task,TaskOutput,TaskStop".to_owned(),
+            "run".to_owned(),
+            "--format".to_owned(),
+            "json".to_owned(),
         ],
         timeout_seconds: default_backend_timeout_seconds(),
         enabled: BackendEnabled::Disabled,
-        env: BTreeMap::from([
-            (
-                "ANTHROPIC_BASE_URL".to_owned(),
-                "https://openrouter.ai/api".to_owned(),
-            ),
-            ("ANTHROPIC_API_KEY".to_owned(), String::new()),
-        ]),
-        models: BackendRoleModels {
-            planner: Some("opus".to_owned()),
-            implementer: Some("opus".to_owned()),
-            reviewer: Some("opus".to_owned()),
-            final_reviewer: Some("opus".to_owned()),
-            arbiter: Some("opus".to_owned()),
-            qa: Some("opus".to_owned()),
-            completer: Some("opus".to_owned()),
-            acceptance_qa: Some("opus".to_owned()),
-            reformatter: Some("sonnet".to_owned()),
-        },
+        env: BTreeMap::new(),
+        models: BackendRoleModels::default(),
         role_timeouts: RoleTimeouts::default(),
     }
 }

--- a/src/project/lifecycle.rs
+++ b/src/project/lifecycle.rs
@@ -739,7 +739,7 @@ fn reconstruct_completion_attempt(
                     .frontmatter
                     .get("backend")
                     .cloned()
-                    .unwrap_or_else(|| String::new());
+                    .unwrap_or_default();
                 completers.push(backend);
                 if let Some(pv) = parse_completion_verdict(&v.body) {
                     any_verdict = true;
@@ -775,7 +775,7 @@ fn reconstruct_completion_attempt(
                 .frontmatter
                 .get("backend")
                 .cloned()
-                .unwrap_or_else(|| String::new());
+                .unwrap_or_default();
             let verdict = parse_completion_verdict(&single.body);
             (vec![backend], Some(single), verdict)
         } else {
@@ -792,7 +792,7 @@ fn reconstruct_completion_attempt(
                     .frontmatter
                     .get("backend")
                     .cloned()
-                    .unwrap_or_else(|| String::new()),
+                    .unwrap_or_default(),
                 passed: true,
                 artifact: artifact.rel_path.clone(),
             });
@@ -807,7 +807,7 @@ fn reconstruct_completion_attempt(
                     .frontmatter
                     .get("backend")
                     .cloned()
-                    .unwrap_or_else(|| String::new()),
+                    .unwrap_or_default(),
                 passed: false,
                 artifact: artifact.rel_path.clone(),
             });
@@ -827,7 +827,7 @@ fn reconstruct_completion_attempt(
 
     let planner_backend = termination
         .and_then(|artifact| artifact.frontmatter.get("backend").cloned())
-        .unwrap_or_else(|| String::new());
+        .unwrap_or_default();
 
     CompletionLoopState {
         loop_number,


### PR DESCRIPTION
## Summary
- Switches the openrouter backend from using `claude` CLI (with Anthropic API env var hacks) to `opencode` CLI, which natively supports OpenRouter and 75+ LLM providers
- Adds opencode NDJSON event parsing (`step_start`, `text`, `step_finish`) to the output normalizer
- Adds session resume support via `--session <id>` and `--format json` arg rewriting

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib` — 801 tests pass
- [ ] Integration test: enable openrouter in config, run a task via daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)