### PR TITLE
config: update openrouter to use opencode CLI with gpt-5.2-codex

### DIFF
--- a/.ralph/ralph.toml
+++ b/.ralph/ralph.toml
@@ -77,31 +77,27 @@ reformatter = "gpt-5.3-codex-medium"
 [backends.codex.role_timeouts]
 
 [backends.openrouter]
-command = "claude"
+command = "opencode"
 args = [
-    "-p",
-    "--permission-mode",
-    "acceptEdits",
-    "--allowedTools",
-    "Bash,Edit,Write,Read,Glob,Grep,WebSearch,WebFetch,Task,TaskOutput,TaskStop",
+    "run",
+    "--format",
+    "json",
 ]
 timeout_seconds = 7200
 enabled = "auto"
 
 [backends.openrouter.env]
-ANTHROPIC_BASE_URL = "https://openrouter.ai/api"
-ANTHROPIC_API_KEY = ""
 
 [backends.openrouter.models]
-planner = "openai/gpt-5.3-codex"
-implementer = "openai/gpt-5.3-codex"
-reviewer = "openai/gpt-5.3-codex"
-final_reviewer = "openai/gpt-5.3-codex"
-arbiter = "openai/gpt-5.3-codex"
-qa = "openai/gpt-5.3-codex"
-completer = "openai/gpt-5.3-codex"
-acceptance_qa = "openai/gpt-5.3-codex"
-reformatter = "openai/gpt-5.3-codex"
+planner = "openrouter/openai/gpt-5.2-codex"
+implementer = "openrouter/openai/gpt-5.2-codex"
+reviewer = "openrouter/openai/gpt-5.2-codex"
+final_reviewer = "openrouter/openai/gpt-5.2-codex"
+arbiter = "openrouter/openai/gpt-5.2-codex"
+qa = "openrouter/openai/gpt-5.2-codex"
+completer = "openrouter/openai/gpt-5.2-codex"
+acceptance_qa = "openrouter/openai/gpt-5.2-codex"
+reformatter = "openrouter/openai/gpt-5.2-codex"
 
 [backends.openrouter.role_timeouts]
 


### PR DESCRIPTION
## Summary
- Updates openrouter config to use `opencode` command instead of `claude`
- Uses `openrouter/openai/gpt-5.2-codex` model IDs (latest codex on OpenRouter)
- Removes Anthropic API env var hacks (no longer needed with opencode)

## Test plan
- [ ] Retrigger issue #115 with new config

🤖 Generated with [Claude Code](https://claude.com/claude-code)