### PR TITLE
feat: switch openrouter backend to goose CLI

### DIFF
--- a/.ralph/ralph.toml
+++ b/.ralph/ralph.toml
@@ -77,11 +77,17 @@ reformatter = "gpt-5.3-codex-medium"
 [backends.codex.role_timeouts]
 
 [backends.openrouter]
-command = "opencode"
+command = "goose"
 args = [
     "run",
-    "--format",
-    "json",
+    "--no-profile",
+    "--quiet",
+    "--with-builtin",
+    "developer",
+    "--output-format",
+    "stream-json",
+    "-i",
+    "-",
 ]
 timeout_seconds = 7200
 enabled = "auto"
@@ -89,15 +95,15 @@ enabled = "auto"
 [backends.openrouter.env]
 
 [backends.openrouter.models]
-planner = "openrouter/openai/gpt-5.2-codex"
-implementer = "openrouter/openai/gpt-5.2-codex"
-reviewer = "openrouter/openai/gpt-5.2-codex"
-final_reviewer = "openrouter/openai/gpt-5.2-codex"
-arbiter = "openrouter/openai/gpt-5.2-codex"
-qa = "openrouter/openai/gpt-5.2-codex"
-completer = "openrouter/openai/gpt-5.2-codex"
-acceptance_qa = "openrouter/openai/gpt-5.2-codex"
-reformatter = "openrouter/openai/gpt-5.2-codex"
+planner = "openai/gpt-5.3-codex"
+implementer = "openai/gpt-5.3-codex"
+reviewer = "openai/gpt-5.3-codex"
+final_reviewer = "openai/gpt-5.3-codex"
+arbiter = "openai/gpt-5.3-codex"
+qa = "openai/gpt-5.3-codex"
+completer = "openai/gpt-5.3-codex"
+acceptance_qa = "openai/gpt-5.3-codex"
+reformatter = "openai/gpt-5.2-codex"
 
 [backends.openrouter.role_timeouts]
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -227,7 +227,7 @@ impl CliBackend {
             Some(id) => match self.name.as_str() {
                 n if n.starts_with("claude") || n == "claude" => self.effective_args_claude(id),
                 n if n.starts_with("openrouter") || n == "openrouter" => {
-                    self.effective_args_opencode(id)
+                    self.effective_args_goose(id)
                 }
                 n if n.starts_with("codex") || n == "codex" => self.effective_args_codex(id),
                 n if n.starts_with("gemini") || n == "gemini" => self.effective_args_gemini(id),
@@ -297,17 +297,17 @@ impl CliBackend {
                         skip_next = false;
                         continue;
                     }
-                    if arg == "--format" {
+                    if arg == "--output-format" {
                         skip_next = true;
                         continue;
                     }
-                    if arg.starts_with("--format=") {
+                    if arg.starts_with("--output-format=") {
                         continue;
                     }
                     args.push(arg.clone());
                 }
-                args.push("--format".to_owned());
-                args.push("json".to_owned());
+                args.push("--output-format".to_owned());
+                args.push("stream-json".to_owned());
                 Ok(args)
             }
             _ => Ok(self.args.clone()),
@@ -459,11 +459,11 @@ impl CliBackend {
         Ok(result)
     }
 
-    fn effective_args_opencode(&self, session_id: &str) -> Result<Vec<String>> {
-        // OpenCode resume rules:
+    fn effective_args_goose(&self, session_id: &str) -> Result<Vec<String>> {
+        // Goose resume rules:
         // 1. Keep all existing args.
-        // 2. Remove existing --session and --format forms.
-        // 3. Add --session <id> and --format json.
+        // 2. Remove existing --name, --session-id, --output-format forms and --resume flag.
+        // 3. Add --name <id> --resume --output-format stream-json.
         let mut result = Vec::new();
         let mut skip_next = false;
 
@@ -472,20 +472,28 @@ impl CliBackend {
                 skip_next = false;
                 continue;
             }
-            if arg == "--session" || arg == "-s" || arg == "--format" || arg == "-f" {
+            if arg == "--name" || arg == "-n" || arg == "--session-id" || arg == "--output-format"
+            {
                 skip_next = true;
                 continue;
             }
-            if arg.starts_with("--session=") || arg.starts_with("--format=") {
+            if arg.starts_with("--name=")
+                || arg.starts_with("--session-id=")
+                || arg.starts_with("--output-format=")
+            {
+                continue;
+            }
+            if arg == "--resume" || arg == "-r" {
                 continue;
             }
             result.push(arg.clone());
         }
 
-        result.push("--session".to_owned());
+        result.push("--name".to_owned());
         result.push(session_id.to_owned());
-        result.push("--format".to_owned());
-        result.push("json".to_owned());
+        result.push("--resume".to_owned());
+        result.push("--output-format".to_owned());
+        result.push("stream-json".to_owned());
         Ok(result)
     }
 

--- a/src/backend/openrouter.rs
+++ b/src/backend/openrouter.rs
@@ -13,8 +13,14 @@ pub fn backend_from_config(
     let backend = &config.backends.openrouter;
     let mut args = backend.args.clone();
     let name = if let Some(model_name) = model {
-        // Inject -m <model> before the "run" subcommand.
-        args.splice(0..0, ["-m".to_owned(), model_name.to_owned()]);
+        // Inject --model <model> after the "run" subcommand (or at end if no "run").
+        if let Some(pos) = args.iter().position(|a| a == "run") {
+            args.insert(pos + 1, model_name.to_owned());
+            args.insert(pos + 1, "--model".to_owned());
+        } else {
+            args.push("--model".to_owned());
+            args.push(model_name.to_owned());
+        }
         format!("openrouter({model_name})")
     } else {
         "openrouter".to_owned()

--- a/src/backend/output_normalizer.rs
+++ b/src/backend/output_normalizer.rs
@@ -38,6 +38,9 @@ const STREAM_EVENT_TYPES: &[&str] = &[
     "message",
     "tool_use",
     "tool_result",
+    // Goose CLI
+    "complete",
+    "notification",
     // OpenCode CLI
     "step_start",
 ];
@@ -193,7 +196,38 @@ pub fn normalize_claude_stream_json(raw: &str) -> Result<NormalizedOutput> {
                 }
             }
             "message" => {
-                if event.get("role").and_then(Value::as_str) == Some("assistant") {
+                // Goose CLI wraps messages in {"type":"message","message":{...}}.
+                // Gemini CLI has {"type":"message","role":"assistant","content":"..."}.
+                if let Some(inner) = event.get("message") {
+                    // Goose format: extract text from inner message.content[]
+                    // Only extract "text" type content, skip "reasoning" and "toolRequest".
+                    let role = inner.get("role").and_then(Value::as_str);
+                    if role == Some("assistant") {
+                        if let Some(items) = inner.pointer("/content").and_then(Value::as_array) {
+                            for item in items {
+                                let ct = item.get("type").and_then(Value::as_str);
+                                if ct == Some("text") {
+                                    if let Some(text) = item.get("text").and_then(Value::as_str) {
+                                        if !output.text.is_empty()
+                                            && !output.text.ends_with('\n')
+                                        {
+                                            output.text.push('\n');
+                                        }
+                                        output.text.push_str(text);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    // Extract session from inner message.id
+                    if output.session_id.is_none() {
+                        output.session_id = inner
+                            .get("id")
+                            .and_then(Value::as_str)
+                            .map(str::to_owned);
+                    }
+                } else if event.get("role").and_then(Value::as_str) == Some("assistant") {
+                    // Gemini format: role at top level
                     if let Some(content) = event.get("content") {
                         if let Some(text) = extract_text_from_content(content) {
                             if !output.text.is_empty() && !output.text.ends_with('\n') {
@@ -264,6 +298,21 @@ pub fn normalize_claude_stream_json(raw: &str) -> Result<NormalizedOutput> {
                 merge_usage_from_event(&event, &mut output);
             }
             "turn.started" => {}
+
+            // --- Goose CLI events ---
+            "complete" => {
+                // Final event: {"type":"complete","total_tokens":N}
+                if let Some(total) = event.get("total_tokens").and_then(Value::as_u64) {
+                    // total_tokens is the sum; we don't get a breakdown, but
+                    // store in tokens_in if no prior value (best-effort).
+                    if output.tokens_in.is_none() && output.tokens_out.is_none() {
+                        output.tokens_in = Some(total);
+                    }
+                }
+            }
+            "notification" => {
+                // Log/notification events from goose extensions; skip.
+            }
 
             // --- OpenCode CLI events ---
             "step_start" => {
@@ -1010,6 +1059,63 @@ Done."#;
         assert!(
             !normalized.text.contains("written to file"),
             "should not use the short summary result"
+        );
+    }
+
+    // --- Goose CLI output ---
+
+    #[test]
+    fn normalize_output_goose_cli_extracts_text_and_tokens() {
+        let raw = concat!(
+            r#"{"type":"message","message":{"id":"gen-abc123","role":"assistant","created":1772238503,"content":[{"type":"text","text":"Hello from goose!"}],"metadata":{"userVisible":true}}}"#,
+            "\n",
+            r#"{"type":"complete","total_tokens":1073}"#,
+        );
+        let normalized = normalize_output(raw).expect("goose cli");
+        assert_eq!(normalized.text, "Hello from goose!");
+        assert_eq!(normalized.session_id.as_deref(), Some("gen-abc123"));
+        assert_eq!(normalized.tokens_in, Some(1073));
+    }
+
+    #[test]
+    fn normalize_output_goose_cli_filters_reasoning_and_notifications() {
+        let raw = concat!(
+            r#"{"type":"message","message":{"id":"gen-xyz","role":"assistant","created":1,"content":[{"type":"reasoning","text":"thinking..."}],"metadata":{}}}"#,
+            "\n",
+            r#"{"type":"notification","extension_id":"call_1","log":{"message":"running shell"}}"#,
+            "\n",
+            "{\"type\":\"message\",\"message\":{\"id\":\"gen-xyz\",\"role\":\"assistant\",\"created\":2,\"content\":[{\"type\":\"text\",\"text\":\"# Implementation Notes\\n\\nDone.\"}],\"metadata\":{}}}",
+            "\n",
+            r#"{"type":"complete","total_tokens":500}"#,
+        );
+        let normalized = normalize_output(raw).expect("goose filters reasoning");
+        assert_eq!(normalized.text, "# Implementation Notes\n\nDone.");
+        assert!(
+            !normalized.text.contains("thinking"),
+            "reasoning text should be filtered out"
+        );
+    }
+
+    #[test]
+    fn normalize_output_goose_cli_multiple_text_messages() {
+        let raw = concat!(
+            r#"{"type":"message","message":{"id":"gen-1","role":"assistant","created":1,"content":[{"type":"text","text":"First part."}],"metadata":{}}}"#,
+            "\n",
+            r#"{"type":"message","message":{"id":"gen-1","role":"user","created":2,"content":[{"type":"toolResponse","id":"call_1","toolResult":{}}],"metadata":{}}}"#,
+            "\n",
+            "{\"type\":\"message\",\"message\":{\"id\":\"gen-1\",\"role\":\"assistant\",\"created\":3,\"content\":[{\"type\":\"text\",\"text\":\"# Final Answer\\n\\nAll done.\"}],\"metadata\":{}}}",
+            "\n",
+            r#"{"type":"complete","total_tokens":2000}"#,
+        );
+        let normalized = normalize_output(raw).expect("goose multi text");
+        assert!(
+            normalized.text.contains("\n# Final Answer"),
+            "H1 heading must be on its own line; got: {:?}",
+            normalized.text,
+        );
+        assert_eq!(
+            normalized.text,
+            "First part.\n# Final Answer\n\nAll done."
         );
     }
 

--- a/src/config/global.rs
+++ b/src/config/global.rs
@@ -803,11 +803,17 @@ fn default_gemini_backend_config() -> BackendConfig {
 
 fn default_openrouter_backend_config() -> BackendConfig {
     BackendConfig {
-        command: "opencode".to_owned(),
+        command: "goose".to_owned(),
         args: vec![
             "run".to_owned(),
-            "--format".to_owned(),
-            "json".to_owned(),
+            "--no-profile".to_owned(),
+            "--quiet".to_owned(),
+            "--with-builtin".to_owned(),
+            "developer".to_owned(),
+            "--output-format".to_owned(),
+            "stream-json".to_owned(),
+            "-i".to_owned(),
+            "-".to_owned(),
         ],
         timeout_seconds: default_backend_timeout_seconds(),
         enabled: BackendEnabled::Disabled,


### PR DESCRIPTION
## Summary
- Replaces opencode CLI with [goose](https://github.com/block/goose) (by Block, Linux Foundation) as the CLI tool for the openrouter backend
- Goose supports gpt-5.3-codex via OpenRouter (opencode's model registry was frozen and didn't include it)
- Adds NDJSON event handling for goose's stream-json format (message, complete, notification events)
- Updates session resume to use goose's `--name <id> --resume` syntax
- Config updated to use `openai/gpt-5.3-codex` for all roles (except reformatter on gpt-5.2-codex)

## Why
opencode-ai/opencode is abandoned (maintainer moved to Crush/charmbracelet). Crush lacks JSON output and session resume. Goose has both, plus first-class OpenRouter support and gpt-5.3-codex availability.

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib` — 804 passed, 0 failed
- [x] Goose CLI manually tested: stdin prompt, stream-json output, session resume, gpt-5.3-codex model
- [ ] End-to-end daemon test with real issue

Generated with [Claude Code](https://claude.com/claude-code)