### PR TITLE
fix: use config-based PRD backend defaults instead of hardcoded codex

### DIFF
--- a/src/cli/auto.rs
+++ b/src/cli/auto.rs
@@ -18,9 +18,9 @@ const MAX_PROJECT_NAME_LEN: usize = 60;
 pub struct AutoArgs {
     #[arg(long, value_parser = parse_non_empty_idea)]
     pub idea: String,
-    #[arg(long, default_value = "claude")]
+    #[arg(long, default_value = "")]
     pub spec_writer: String,
-    #[arg(long, default_value = "codex")]
+    #[arg(long, default_value = "")]
     pub spec_reviewer: String,
     #[arg(long, default_value_t = 1, value_parser = parse_positive_u32)]
     pub max_spec_revisions: u32,
@@ -142,12 +142,12 @@ pub async fn execute(args: AutoArgs) -> Result<()> {
     let workspace = ensure_workspace()?;
 
     let writer_spec = if spec_writer.trim().is_empty() {
-        workspace.config.workspace.default_backend.clone()
+        workspace.config.workspace.daemon_prd_writer_backend.clone()
     } else {
         spec_writer
     };
     let reviewer_spec = if spec_reviewer.trim().is_empty() {
-        workspace.config.workspace.default_backend.clone()
+        workspace.config.workspace.daemon_prd_reviewer_backend.clone()
     } else {
         spec_reviewer
     };
@@ -336,8 +336,8 @@ mod tests {
         };
 
         assert_eq!(args.idea, "test feature");
-        assert_eq!(args.spec_writer, "claude");
-        assert_eq!(args.spec_reviewer, "codex");
+        assert_eq!(args.spec_writer, "");
+        assert_eq!(args.spec_reviewer, "");
         assert_eq!(args.max_spec_revisions, 1);
         assert!(args.project_id.is_none());
         assert!(args.backend.is_none());

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -465,8 +465,8 @@ mod tests {
         };
 
         assert_eq!(args.idea, "add retry logic");
-        assert_eq!(args.writer_backend, "claude");
-        assert_eq!(args.reviewer_backend, "codex");
+        assert_eq!(args.writer_backend, "");
+        assert_eq!(args.reviewer_backend, "");
         assert_eq!(args.max_revisions, 1);
         assert!(!args.non_interactive);
         assert!(!args.interactive);

--- a/src/cli/quick_prd.rs
+++ b/src/cli/quick_prd.rs
@@ -14,9 +14,9 @@ use crate::Result;
 pub struct QuickPrdArgs {
     #[arg(long)]
     pub idea: String,
-    #[arg(long, default_value = "claude")]
+    #[arg(long, default_value = "")]
     pub writer_backend: String,
-    #[arg(long, default_value = "codex")]
+    #[arg(long, default_value = "")]
     pub reviewer_backend: String,
     #[arg(long, default_value_t = 1, value_parser = parse_positive_u32)]
     pub max_revisions: u32,
@@ -54,12 +54,12 @@ pub async fn execute(args: QuickPrdArgs) -> Result<()> {
     );
 
     let writer_spec = if args.writer_backend.trim().is_empty() {
-        workspace.config.workspace.default_backend.clone()
+        workspace.config.workspace.daemon_prd_writer_backend.clone()
     } else {
         args.writer_backend.clone()
     };
     let reviewer_spec = if args.reviewer_backend.trim().is_empty() {
-        workspace.config.workspace.default_backend.clone()
+        workspace.config.workspace.daemon_prd_reviewer_backend.clone()
     } else {
         args.reviewer_backend.clone()
     };


### PR DESCRIPTION
## Summary
- `ralph auto` and `ralph quick-prd` had hardcoded CLI defaults `--spec-writer claude` and `--spec-reviewer codex`
- When the daemon spawned `ralph auto` without these flags, it always used codex as the PRD reviewer, causing `error: backend unavailable: codex` when codex is disabled
- Changed defaults to empty string, falling through to `daemon_prd_writer_backend` and `daemon_prd_reviewer_backend` from ralph.toml config

## Test plan
- [x] All 804 unit tests pass
- [ ] Daemon picks up issue #127 and runs PRD phase with openrouter (goose) backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)