### PR TITLE
fix: resolve openrouter model from config when not specified in spec

### DIFF
--- a/src/backend/openrouter.rs
+++ b/src/backend/openrouter.rs
@@ -12,7 +12,16 @@ pub fn backend_from_config(
 ) -> CliBackend {
     let backend = &config.backends.openrouter;
     let mut args = backend.args.clone();
-    let name = if let Some(model_name) = model {
+
+    // Resolve model: explicit spec model > role-based config model > implementer fallback
+    let resolved_model = model
+        .map(|m| m.to_owned())
+        .or_else(|| {
+            role.and_then(|r| backend.models.for_role(r).map(|m| m.to_owned()))
+        })
+        .or_else(|| backend.models.implementer.clone());
+
+    let name = if let Some(ref model_name) = resolved_model {
         // Inject --model <model> after the "run" subcommand (or at end if no "run").
         if let Some(pos) = args.iter().position(|a| a == "run") {
             args.insert(pos + 1, model_name.to_owned());


### PR DESCRIPTION
## Summary
- When `openrouter` is used as a bare backend spec (no model in parens), goose panics with "No model configured"
- Now resolves the model from: (1) explicit spec model, (2) role-based config model, (3) implementer model fallback
- Fixes daemon PRD phase where reviewer backend is bare `openrouter`

## Context
Follows PR #129 which fixed PRD backend defaults. The PRD reviewer is now correctly set to `openrouter`, but since no model is specified in the spec string, goose receives no `--model` flag and panics. This fix ensures the model is always resolved from the config when not explicitly provided.

## Test plan
- [x] All 804 unit tests pass
- [ ] Daemon PRD phase succeeds with bare `openrouter` reviewer backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)