### PR TITLE
chore: add completion_backends config to replace codex default

### DIFF
--- a/.ralph/ralph.toml
+++ b/.ralph/ralph.toml
@@ -146,6 +146,11 @@ final_review_arbiter_backend = "openrouter"
 final_review_min_reviewers = 2
 final_review_consensus_threshold = 1.0
 max_final_review_restarts = 15
+completion_backends = [
+    "claude",
+    "openrouter",
+]
+completion_min_completers = 2
 qa_enabled = false
 max_qa_iterations = 3
 planner_state_in_prompt = "summary"


### PR DESCRIPTION
## Summary
- The hardcoded default for `completion_backends` is `["claude", "codex", "?gemini"]`
- Since codex is disabled, the completion phase fails with `backend unavailable: codex`
- Add explicit `completion_backends = ["claude", "openrouter"]` to ralph.toml

## Context
After fixing PRD reviewer (PR #129), model resolution (PR #130), and token streaming (PR #131), the end-to-end daemon test progresses through the full orchestration loop (planning, implementing, reviewing) but fails at the completion phase due to this hardcoded codex default.

## Test plan
- [ ] Daemon completes the full orchestration cycle including completion phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)