### PR TITLE
fix: detect credits exhaustion and stop retrying after review/QA limit

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -145,6 +145,10 @@ impl RalphError {
                     || details.contains("MODEL_CAPACITY_EXHAUSTED")
                     || details.contains("quota will reset")
                     || details.contains("hit your usage limit")
+                    || details.contains("creditsExhausted")
+                    || details.contains("add more credits")
+                    || details.contains("insufficient_quota")
+                    || details.contains("billing_hard_limit_reached")
             }
             _ => false,
         }
@@ -206,6 +210,37 @@ mod tests {
         let debug = format!("{err:?}");
         assert!(debug.contains("idle_seconds: 30"));
         assert!(debug.contains("timeout_kind: Walltime"));
+    }
+
+    #[test]
+    fn is_quota_error_matches_known_patterns() {
+        let patterns = [
+            "TerminalQuotaError",
+            "RESOURCE_EXHAUSTED",
+            "MODEL_CAPACITY_EXHAUSTED",
+            "quota will reset",
+            "hit your usage limit",
+            "creditsExhausted",
+            "add more credits",
+            "insufficient_quota",
+            "billing_hard_limit_reached",
+        ];
+        for pat in patterns {
+            let err = RalphError::BackendCommandFailed {
+                backend: "test".to_owned(),
+                details: format!("error: {pat} occurred"),
+            };
+            assert!(err.is_quota_error(), "expected is_quota_error() for: {pat}");
+        }
+    }
+
+    #[test]
+    fn is_quota_error_rejects_unrelated_errors() {
+        let err = RalphError::BackendCommandFailed {
+            backend: "test".to_owned(),
+            details: "parse error: missing top-level H1".to_owned(),
+        };
+        assert!(!err.is_quota_error());
     }
 
     #[test]

--- a/src/workflow/orchestrator.rs
+++ b/src/workflow/orchestrator.rs
@@ -1248,12 +1248,6 @@ impl Orchestrator {
                             state = state_before_rollback;
                             return Err(err);
                         }
-                        if options.until_complete {
-                            logs.push(format!(
-                                "loop {ln}: QA iteration limit ({max_iter}) exceeded; rolled back, retrying"
-                            ));
-                            continue;
-                        }
                         return Err(RalphError::QaIterationLimitExceeded {
                             loop_number: ln,
                             max_iterations: max_iter,
@@ -2289,12 +2283,6 @@ impl Orchestrator {
                 ) {
                     state = state_before_rollback;
                     return Err(err);
-                }
-                if options.until_complete {
-                    logs.push(format!(
-                        "loop {ln}: review iteration limit ({max_iter}) exceeded; rolled back, retrying"
-                    ));
-                    continue;
                 }
                 return Err(RalphError::ReviewIterationLimitExceeded {
                     loop_number: ln,
@@ -5174,6 +5162,28 @@ where
         repo_root,
     )
     .await?;
+
+    // Detect quota/credits exhaustion in raw output. Some backends (e.g. OpenRouter)
+    // exit 0 but return only a notification instead of content. Catch this early to avoid
+    // sending empty/garbage output to the reformatter, which would fabricate a fake response.
+    const QUOTA_OUTPUT_PATTERNS: &[&str] = &[
+        "creditsExhausted",
+        "add more credits",
+        "insufficient_quota",
+        "billing_hard_limit_reached",
+    ];
+    if let Some(pat) = QUOTA_OUTPUT_PATTERNS
+        .iter()
+        .find(|p| first_raw.contains(**p))
+    {
+        return Err(RalphError::BackendCommandFailed {
+            backend: backend_name.clone(),
+            details: format!(
+                "quota/credits error detected in output ({pat}): \
+                 backend returned a credits-exhausted notification instead of content"
+            ),
+        });
+    }
 
     // If output is empty/near-empty, retry with the same backend before going to the
     // reformatter. Empty responses indicate a backend execution issue (e.g. token limits,


### PR DESCRIPTION
## Summary
- Detect OpenRouter `creditsExhausted` notifications in raw backend output and fail immediately instead of sending empty output to the reformatter (which fabricates fake responses)
- Add `creditsExhausted`, `add more credits`, `insufficient_quota`, `billing_hard_limit_reached` to `is_quota_error()` patterns
- Stop retrying loops after `ReviewIterationLimitExceeded` and `QaIterationLimitExceeded` — these now always abort instead of rolling back and replanning indefinitely in `until_complete` mode

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --lib` — 807 passed, 0 failed
- [x] New `is_quota_error` unit tests added and passing
- [x] Validate conformance tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)