### PR TITLE
Switch openrouter backend to codex with gpt-5.3-codex-spark

### DIFF
--- a/.ralph/ralph.toml
+++ b/.ralph/ralph.toml
@@ -17,10 +17,10 @@ daemon_rebase_agent_backend = "claude(opus)"
 daemon_prd_enabled = true
 daemon_prd_question_backends = [
     "claude",
-    "openrouter",
+    "codex",
 ]
 daemon_prd_writer_backend = "claude"
-daemon_prd_reviewer_backend = "openrouter"
+daemon_prd_reviewer_backend = "codex"
 daemon_prd_max_revisions = 3
 daemon_prd_backend_timeout_secs = 3600
 
@@ -59,20 +59,20 @@ args = [
     "-",
 ]
 timeout_seconds = 7200
-enabled = false
+enabled = "auto"
 
 [backends.codex.env]
 
 [backends.codex.models]
-planner = "gpt-5.3-codex-xhigh"
-implementer = "gpt-5.3-codex-high"
-reviewer = "gpt-5.3-codex-high"
-final_reviewer = "gpt-5.3-codex-xhigh"
-arbiter = "gpt-5.3-codex-xhigh"
-qa = "gpt-5.3-codex-high"
-completer = "gpt-5.3-codex-xhigh"
-acceptance_qa = "gpt-5.3-codex-xhigh"
-reformatter = "gpt-5.3-codex-medium"
+planner = "gpt-5.3-codex-spark-xhigh"
+implementer = "gpt-5.3-codex-spark-xhigh"
+reviewer = "gpt-5.3-codex-spark-xhigh"
+final_reviewer = "gpt-5.3-codex-spark-xhigh"
+arbiter = "gpt-5.3-codex-spark-xhigh"
+qa = "gpt-5.3-codex-spark-xhigh"
+completer = "gpt-5.3-codex-spark-xhigh"
+acceptance_qa = "gpt-5.3-codex-spark-xhigh"
+reformatter = "gpt-5.3-codex-spark-medium"
 
 [backends.codex.role_timeouts]
 
@@ -92,7 +92,7 @@ args = [
     "-",
 ]
 timeout_seconds = 7200
-enabled = "auto"
+enabled = false
 
 [backends.openrouter.env]
 
@@ -136,19 +136,19 @@ commit_message_style = "conventional"
 commit_tag_format = "ralph/{project_id}/loop-{loop_number}"
 prompt_change_action = "abort"
 prompt_review_enabled = true
-prompt_review_backend = "openrouter"
+prompt_review_backend = "codex"
 final_review_enabled = true
 final_review_backends = [
     "claude",
-    "openrouter",
+    "codex",
 ]
-final_review_arbiter_backend = "openrouter"
+final_review_arbiter_backend = "codex"
 final_review_min_reviewers = 2
 final_review_consensus_threshold = 1.0
 max_final_review_restarts = 15
 completion_backends = [
     "claude",
-    "openrouter",
+    "codex",
 ]
 completion_min_completers = 2
 qa_enabled = false


### PR DESCRIPTION
## Summary
- Replace goose/OpenRouter routing with direct codex CLI using `gpt-5.3-codex-spark-xhigh`
- All roles use xhigh effort except reformatter (medium)

## Test plan
- Config-only change, no code modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)