### PR TITLE
Fix codex backend command name

### DIFF
--- a/.ralph/ralph.toml
+++ b/.ralph/ralph.toml
@@ -52,7 +52,7 @@ reformatter = "sonnet"
 [backends.claude.role_timeouts]
 
 [backends.codex]
-command = "openrouter"
+command = "codex"
 args = [
     "exec",
     "--dangerously-bypass-approvals-and-sandbox",


### PR DESCRIPTION
## Summary
- Fix codex backend `command` from `openrouter` to `codex` — the actual CLI binary name

## Test plan
- Config-only fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)