### PR TITLE
Add git hooks for fmt, clippy, and nix build

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v nix >/dev/null 2>&1 && [ -f "flake.nix" ]; then
+    if ! nix develop -c cargo fmt --check 2>/dev/null; then
+        echo "Code is not formatted. Run 'nix develop -c cargo fmt' before committing."
+        echo ""
+        echo "To see what needs formatting:"
+        echo "  nix develop -c cargo fmt --check --verbose"
+        exit 1
+    fi
+else
+    if ! cargo fmt --check 2>/dev/null; then
+        echo "Code is not formatted. Run 'cargo fmt' before committing."
+        exit 1
+    fi
+fi
+
+echo "Formatting check passed"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Running pre-push checks..."
+echo ""
+
+if command -v nix >/dev/null 2>&1 && [ -f "flake.nix" ]; then
+    echo "Checking code formatting..."
+    if ! nix develop -c cargo fmt --check 2>/dev/null; then
+        echo ""
+        echo "Code is not formatted. Run 'nix develop -c cargo fmt' before pushing."
+        exit 1
+    fi
+    echo "Formatting check passed"
+    echo ""
+
+    echo "Running clippy..."
+    if ! nix develop -c cargo clippy --all-targets -- -D warnings 2>&1; then
+        echo ""
+        echo "Clippy found issues. Fix them before pushing."
+        echo ""
+        echo "To attempt automatic fixes:"
+        echo "  nix develop -c cargo clippy --fix --allow-dirty"
+        exit 1
+    fi
+    echo "Clippy check passed"
+    echo ""
+
+    echo "Running nix build..."
+    if ! nix build -L 2>&1; then
+        echo ""
+        echo "nix build failed. Fix build errors before pushing."
+        exit 1
+    fi
+    echo "Build passed"
+else
+    echo "Checking code formatting..."
+    if ! cargo fmt --check 2>/dev/null; then
+        echo ""
+        echo "Code is not formatted. Run 'cargo fmt' before pushing."
+        exit 1
+    fi
+    echo "Formatting check passed"
+    echo ""
+
+    echo "Running clippy..."
+    if ! cargo clippy --all-targets -- -D warnings 2>&1; then
+        echo ""
+        echo "Clippy found issues. Fix them before pushing."
+        exit 1
+    fi
+    echo "Clippy check passed"
+fi
+
+echo ""
+echo "All pre-push checks passed!"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,15 @@ src/
   workspace/   # Workspace discovery and management
 ```
 
+## Commit & PR messages
+
+- Never mention Claude, Codex, or any other AI agent name in commit messages or PR descriptions. These are not a place for advertisement.
+
+## Build environment
+
+- Every build should be done through `nix build`.
+- For development tasks, use `nix develop -c` and include any useful dependencies in `flake.nix`.
+
 ## Key conventions
 
 - **Artifact naming**: Implementation response files use timestamp-prefixed filenames (`YYYYMMDDHHMMSS-impl-response-NNN.md`) with YAML frontmatter. See `src/workflow/parser.rs`.

--- a/flake.nix
+++ b/flake.nix
@@ -90,6 +90,19 @@
               ];
 
               RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
+
+              shellHook = ''
+                if [ -d .git ] && [ -d .githooks ]; then
+                  current_hooks_path=$(git config core.hooksPath || echo "")
+                  if [ "$current_hooks_path" != ".githooks" ]; then
+                    git config core.hooksPath .githooks
+                    echo "Git hooks configured (.githooks)"
+                    echo "  pre-commit: cargo fmt --check"
+                    echo "  pre-push:   cargo fmt + clippy + nix build"
+                    echo "  Disable: git config --unset core.hooksPath"
+                  fi
+                fi
+              '';
             };
           }
           // pkgs.lib.optionalAttrs isLinux {


### PR DESCRIPTION
## Summary
- Add pre-commit hook: `cargo fmt --check`
- Add pre-push hook: `cargo fmt --check` + `cargo clippy` + `nix build`
- Auto-configure hooks via `shellHook` in `flake.nix` on `nix develop`
- Document commit/PR and build environment conventions in AGENTS.md