### PR TITLE
chore: switch codex models from spark to non-spark variant

### DIFF
--- a/.ralph/ralph.toml
+++ b/.ralph/ralph.toml
@@ -64,15 +64,15 @@ enabled = "auto"
 [backends.codex.env]
 
 [backends.codex.models]
-planner = "gpt-5.3-codex-spark-xhigh"
-implementer = "gpt-5.3-codex-spark-xhigh"
-reviewer = "gpt-5.3-codex-spark-xhigh"
-final_reviewer = "gpt-5.3-codex-spark-xhigh"
-arbiter = "gpt-5.3-codex-spark-xhigh"
-qa = "gpt-5.3-codex-spark-xhigh"
-completer = "gpt-5.3-codex-spark-xhigh"
-acceptance_qa = "gpt-5.3-codex-spark-xhigh"
-reformatter = "gpt-5.3-codex-spark-medium"
+planner = "gpt-5.3-codex-xhigh"
+implementer = "gpt-5.3-codex-xhigh"
+reviewer = "gpt-5.3-codex-xhigh"
+final_reviewer = "gpt-5.3-codex-xhigh"
+arbiter = "gpt-5.3-codex-xhigh"
+qa = "gpt-5.3-codex-xhigh"
+completer = "gpt-5.3-codex-xhigh"
+acceptance_qa = "gpt-5.3-codex-xhigh"
+reformatter = "gpt-5.3-codex-medium"
 
 [backends.codex.role_timeouts]
 
@@ -89,15 +89,15 @@ enabled = false
 [backends.openrouter.env]
 
 [backends.openrouter.models]
-planner = "gpt-5.3-codex-spark-xhigh"
-implementer = "gpt-5.3-codex-spark-xhigh"
-reviewer = "gpt-5.3-codex-spark-xhigh"
-final_reviewer = "gpt-5.3-codex-spark-xhigh"
-arbiter = "gpt-5.3-codex-spark-xhigh"
-qa = "gpt-5.3-codex-spark-xhigh"
-completer = "gpt-5.3-codex-spark-xhigh"
-acceptance_qa = "gpt-5.3-codex-spark-xhigh"
-reformatter = "gpt-5.3-codex-spark-medium"
+planner = "gpt-5.3-codex-xhigh"
+implementer = "gpt-5.3-codex-xhigh"
+reviewer = "gpt-5.3-codex-xhigh"
+final_reviewer = "gpt-5.3-codex-xhigh"
+arbiter = "gpt-5.3-codex-xhigh"
+qa = "gpt-5.3-codex-xhigh"
+completer = "gpt-5.3-codex-xhigh"
+acceptance_qa = "gpt-5.3-codex-xhigh"
+reformatter = "gpt-5.3-codex-medium"
 
 [backends.openrouter.role_timeouts]
 


### PR DESCRIPTION
## Summary
- Switch from `gpt-5.3-codex-spark-xhigh/medium` to `gpt-5.3-codex-xhigh/medium` to avoid separate quota limits on the spark model

## Test plan
- [x] Config-only change, no code affected
- [x] `nix build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)