### PR TITLE
config: add reviewer_backend for quick-dev workflow

### DIFF
--- a/.ralph/ralph.toml
+++ b/.ralph/ralph.toml
@@ -122,6 +122,7 @@ completer = "gemini-3-pro-preview"
 [backends.gemini.role_timeouts]
 
 [workflow]
+reviewer_backend = "codex"
 max_review_iterations = 30
 auto_commit = true
 commit_message_style = "conventional"


### PR DESCRIPTION
Quick-dev requires a distinct reviewer backend. Set codex as the reviewer so claude (implementer) and codex (reviewer) form the required two-backend pair.