### PR TITLE
fix: strengthen quick-dev review prompts with call-site audit instructions

### DIFF
--- a/src/prompts/quick_dev.rs
+++ b/src/prompts/quick_dev.rs
@@ -77,6 +77,12 @@ CRITICAL FORMAT REQUIREMENTS:
 fn default_quick_dev_codex_review_template() -> &'static str {
     r#"You are the quick-dev reviewer. Evaluate the implementation against the provided specification and current diff.
 
+Review focus:
+1. Does the implementation satisfy the spec requirements?
+2. For new or modified functions: trace all callers in the diff. Verify the change is correct for every code path, not just the intended one. Flag over-broad integration (e.g., a function wired into a generic entry point when it should only run in specific contexts).
+3. Are there logic errors, missing edge cases, or incorrect error handling?
+4. Provide concrete, actionable fixes for any issues found.
+
 CRITICAL FORMAT REQUIREMENTS:
 - Return markdown body only (no YAML frontmatter)
 - Your response MUST begin with one exact, case-sensitive H1 as the VERY FIRST LINE:
@@ -85,7 +91,7 @@ CRITICAL FORMAT REQUIREMENTS:
 - No preamble or commentary before the H1
 
 If satisfied, explain why briefly and confirm the implementation is ready.
-If changes are required, provide concrete, actionable fixes.
+If changes are required, provide concrete, actionable fixes with file paths.
 
 ## Context Provided
 
@@ -133,7 +139,14 @@ CRITICAL FORMAT REQUIREMENTS:
 }
 
 fn default_quick_dev_final_review_template() -> &'static str {
-    r#"You are performing a quick-dev final review pass. Verify whether the implementation is fully complete.
+    r#"You are performing a quick-dev final review pass. Verify whether the implementation is correct, safe, and properly integrated.
+
+Review checklist:
+1. **Correctness**: Does the code do what the spec requires? Are there logic errors, off-by-one mistakes, or missing edge cases?
+2. **Integration safety**: For every new function or modified call site, trace ALL callers. Verify the change is appropriate for every code path that reaches it — not just the intended one. Flag cases where a function is wired into a broad entry point but should only run in specific contexts.
+3. **Side effects**: Could the change cause unintended behavior during unrelated operations? Check that new code guarded by conditions (phase checks, feature flags, etc.) has the correct guards.
+4. **Error handling**: Are errors handled or propagated correctly? No silent failures that mask bugs.
+5. **Stray artifacts**: Are there leftover files, dead code, or debug prints that should be removed?
 
 CRITICAL FORMAT REQUIREMENTS:
 - Return markdown body only (no YAML frontmatter)
@@ -143,7 +156,7 @@ CRITICAL FORMAT REQUIREMENTS:
 - No preamble or commentary before the H1
 
 If complete, briefly confirm all requirements are met.
-If issues are found, list precise blocking issues.
+If issues are found, list precise blocking issues with file paths and line numbers.
 
 ## Context Provided
 


### PR DESCRIPTION
## Summary

- Enhanced codex review (inner loop) prompt to instruct reviewers to trace all callers of new/modified functions and flag over-broad integration points
- Enhanced final review prompt with a 5-point checklist: correctness, integration safety, side effects, error handling, stray artifacts
- Both prompts now request file paths in issue reports

## Motivation

PR #158's codex bot review caught a P2 that neither the quick-dev codex reviewer nor the final reviewers caught: `remove_stray_impl_artifacts()` was wired into `commit_and_push_phase_transition()` which runs on ALL phase transitions, not just implementing→reviewing. The reviewers verified functional correctness against the spec but didn't audit the call-site breadth.

## Test plan

- [x] `cargo check` passes
- [x] All 1,233 tests pass
- [x] No test changes needed (prompt content only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)