### PR TITLE
refactor: unify quick-dev final review with full workflow template

### DIFF
--- a/src/config/global.rs
+++ b/src/config/global.rs
@@ -471,8 +471,6 @@ pub struct TemplateConfig {
     pub quick_dev_codex_review: String,
     #[serde(default = "default_quick_dev_apply_fixes_template_path")]
     pub quick_dev_apply_fixes: String,
-    #[serde(default = "default_quick_dev_final_review_template_path")]
-    pub quick_dev_final_review: String,
     #[serde(default = "default_planner_position_template_path")]
     pub planner_position: String,
     #[serde(default = "default_vote_template_path")]
@@ -689,7 +687,6 @@ impl Default for TemplateConfig {
             quick_dev_plan_implement: default_quick_dev_plan_implement_template_path(),
             quick_dev_codex_review: default_quick_dev_codex_review_template_path(),
             quick_dev_apply_fixes: default_quick_dev_apply_fixes_template_path(),
-            quick_dev_final_review: default_quick_dev_final_review_template_path(),
             planner_position: default_planner_position_template_path(),
             vote: default_vote_template_path(),
             arbiter: default_arbiter_template_path(),
@@ -1090,10 +1087,6 @@ fn default_quick_dev_codex_review_template_path() -> String {
 
 fn default_quick_dev_apply_fixes_template_path() -> String {
     "templates/quick_dev_apply_fixes.md".to_owned()
-}
-
-fn default_quick_dev_final_review_template_path() -> String {
-    "templates/quick_dev_final_review.md".to_owned()
 }
 
 fn default_planner_position_template_path() -> String {
@@ -1567,9 +1560,6 @@ pub(crate) fn set_global_config_value(
         "templates.quick_dev_apply_fixes" => {
             config.templates.quick_dev_apply_fixes = raw_value.to_owned()
         }
-        "templates.quick_dev_final_review" => {
-            config.templates.quick_dev_final_review = raw_value.to_owned()
-        }
         "templates.planner_position" => config.templates.planner_position = raw_value.to_owned(),
         "templates.vote" => config.templates.vote = raw_value.to_owned(),
         "templates.arbiter" => config.templates.arbiter = raw_value.to_owned(),
@@ -1984,10 +1974,6 @@ base_branch = "main"
             config.templates.quick_dev_apply_fixes,
             defaults.templates.quick_dev_apply_fixes
         );
-        assert_eq!(
-            config.templates.quick_dev_final_review,
-            defaults.templates.quick_dev_final_review
-        );
 
         assert_eq!(config.git.base_branch, "main");
         assert_eq!(config.git.auto_branch, defaults.git.auto_branch);
@@ -2102,10 +2088,6 @@ command = "claude-custom"
         assert_eq!(
             config.templates.quick_dev_apply_fixes,
             "templates/quick_dev_apply_fixes.md"
-        );
-        assert_eq!(
-            config.templates.quick_dev_final_review,
-            "templates/quick_dev_final_review.md"
         );
         assert_eq!(
             config.templates.planner_position,
@@ -2341,10 +2323,6 @@ base_branch = "master"
             config.templates.quick_dev_apply_fixes,
             "templates/quick_dev_apply_fixes.md"
         );
-        assert_eq!(
-            config.templates.quick_dev_final_review,
-            "templates/quick_dev_final_review.md"
-        );
     }
 
     #[test]
@@ -2366,10 +2344,6 @@ planner = "templates/custom-spec.md"
         assert_eq!(
             config.templates.quick_dev_apply_fixes,
             "templates/quick_dev_apply_fixes.md"
-        );
-        assert_eq!(
-            config.templates.quick_dev_final_review,
-            "templates/quick_dev_final_review.md"
         );
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -100,7 +100,6 @@ pub struct EffectiveTemplateConfig {
     pub quick_dev_plan_implement: PathBuf,
     pub quick_dev_codex_review: PathBuf,
     pub quick_dev_apply_fixes: PathBuf,
-    pub quick_dev_final_review: PathBuf,
     pub planner_position: PathBuf,
     pub vote: PathBuf,
     pub arbiter: PathBuf,
@@ -422,12 +421,6 @@ pub fn resolve_effective_config(
             project_dir,
             project_ref.and_then(|p| p.templates.quick_dev_apply_fixes.as_deref()),
             &global.templates.quick_dev_apply_fixes,
-        ),
-        quick_dev_final_review: resolve_template_path(
-            workspace_root,
-            project_dir,
-            project_ref.and_then(|p| p.templates.quick_dev_final_review.as_deref()),
-            &global.templates.quick_dev_final_review,
         ),
         planner_position: resolve_template_path(
             workspace_root,
@@ -1154,12 +1147,10 @@ mod tests {
         global.templates.quick_dev_plan_implement = "templates/quick-plan-global.md".to_owned();
         global.templates.quick_dev_codex_review = "templates/quick-codex-global.md".to_owned();
         global.templates.quick_dev_apply_fixes = "templates/quick-apply-global.md".to_owned();
-        global.templates.quick_dev_final_review = "templates/quick-final-global.md".to_owned();
 
         let project = ProjectConfig {
             templates: crate::config::project::ProjectTemplateOverrides {
                 quick_dev_codex_review: Some("templates/quick-codex-project.md".to_owned()),
-                quick_dev_final_review: Some("templates/quick-final-project.md".to_owned()),
                 ..crate::config::project::ProjectTemplateOverrides::default()
             },
             ..ProjectConfig::default()
@@ -1185,10 +1176,6 @@ mod tests {
         assert_eq!(
             effective.templates.quick_dev_apply_fixes,
             Path::new("/workspace/templates/quick-apply-global.md")
-        );
-        assert_eq!(
-            effective.templates.quick_dev_final_review,
-            Path::new("/workspace/project-a/templates/quick-final-project.md")
         );
     }
 

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -82,7 +82,6 @@ pub struct ProjectTemplateOverrides {
     pub quick_dev_plan_implement: Option<String>,
     pub quick_dev_codex_review: Option<String>,
     pub quick_dev_apply_fixes: Option<String>,
-    pub quick_dev_final_review: Option<String>,
     pub planner_position: Option<String>,
     pub vote: Option<String>,
     pub arbiter: Option<String>,

--- a/src/prompts/quick_dev.rs
+++ b/src/prompts/quick_dev.rs
@@ -37,17 +37,6 @@ pub fn build_quick_dev_apply_fixes_prompt(
     )
 }
 
-pub fn build_quick_dev_final_review_prompt(
-    template_path: &Path,
-    vars: &BTreeMap<String, String>,
-) -> Result<String> {
-    render_template_with_fallback(
-        template_path,
-        vars,
-        default_quick_dev_final_review_template(),
-    )
-}
-
 fn default_quick_dev_plan_implement_template() -> &'static str {
     r#"You are a software developer handling the quick-dev plan-and-implement phase.
 
@@ -129,42 +118,6 @@ CRITICAL FORMAT REQUIREMENTS:
 
 ## Reviewer Feedback
 {{review_feedback}}
-
-## Master Prompt
-{{master_prompt}}
-
-## Current Diff
-{{current_diff}}
-"#
-}
-
-fn default_quick_dev_final_review_template() -> &'static str {
-    r#"You are performing a quick-dev final review pass. Verify whether the implementation is correct, safe, and properly integrated.
-
-Review checklist:
-1. **Correctness**: Does the code do what the spec requires? Are there logic errors, off-by-one mistakes, or missing edge cases?
-2. **Integration safety**: For every new function or modified call site, trace ALL callers. Verify the change is appropriate for every code path that reaches it — not just the intended one. Flag cases where a function is wired into a broad entry point but should only run in specific contexts.
-3. **Side effects**: Could the change cause unintended behavior during unrelated operations? Check that new code guarded by conditions (phase checks, feature flags, etc.) has the correct guards.
-4. **Error handling**: Are errors handled or propagated correctly? No silent failures that mask bugs.
-5. **Stray artifacts**: Are there leftover files, dead code, or debug prints that should be removed?
-
-CRITICAL FORMAT REQUIREMENTS:
-- Return markdown body only (no YAML frontmatter)
-- Your response MUST begin with one exact, case-sensitive H1 as the VERY FIRST LINE:
-  - `# Final Review: COMPLETE`
-  - `# Final Review: ISSUES FOUND`
-- No preamble or commentary before the H1
-
-If complete, briefly confirm all requirements are met.
-If issues are found, list precise blocking issues with file paths and line numbers.
-
-## Context Provided
-
-## System Guardrails
-{{system_guardrails}}
-
-## Feature Specification
-{{feature_spec}}
 
 ## Master Prompt
 {{master_prompt}}

--- a/src/validate/mock_scripts.rs
+++ b/src/validate/mock_scripts.rs
@@ -3381,10 +3381,10 @@ esac
 /// Responds to quick-dev prompts that the implementer handles:
 /// - `plan-and-implement phase` → implementation notes output + creates `mock_file.txt`
 /// - `apply-fixes phase` → implementation response
-/// - `final review pass` → `# Final Review: COMPLETE`
+/// - `final reviewer auditing` → `# Final Review: NO AMENDMENTS`
 ///
 /// Environment variable `QUICK_DEV_FINAL_REVIEW_RESULT` controls the final-review
-/// response: "COMPLETE" (default) or "ISSUES FOUND".
+/// response: "NO_AMENDMENTS" (default) or "AMENDMENTS".
 pub fn quick_dev_implementer_mock_script() -> String {
     r###"#!/usr/bin/env bash
 set -euo pipefail
@@ -3418,18 +3418,18 @@ elif grep -q "quick-dev apply-fixes phase" <<< "$INPUT"; then
 EOF
   echo "quick-dev-fixed" >> mock_file.txt
   git add mock_file.txt
-elif grep -q "quick-dev final review pass" <<< "$INPUT"; then
-  result="${QUICK_DEV_FINAL_REVIEW_RESULT:-COMPLETE}"
-  if [ "$result" = "ISSUES FOUND" ]; then
+elif grep -q "final reviewer auditing" <<< "$INPUT"; then
+  result="${QUICK_DEV_FINAL_REVIEW_RESULT:-NO_AMENDMENTS}"
+  if [ "$result" = "AMENDMENTS" ]; then
     cat <<'EOF'
-# Final Review: ISSUES FOUND
+# Final Review: AMENDMENTS
 
 ## Issues
 - Mock issue found by implementer final review.
 EOF
   else
     cat <<'EOF'
-# Final Review: COMPLETE
+# Final Review: NO AMENDMENTS
 
 ## Summary
 All requirements met per implementer review.
@@ -3447,11 +3447,11 @@ fi
 ///
 /// Responds to quick-dev prompts that the reviewer handles:
 /// - `quick-dev reviewer` → `# Review: SATISFIED`
-/// - `final review pass` → `# Final Review: COMPLETE`
+/// - `final reviewer auditing` → `# Final Review: NO AMENDMENTS`
 ///
 /// Environment variables:
 /// - `QUICK_DEV_REVIEW_RESULT`: "SATISFIED" (default) or "CHANGES REQUESTED"
-/// - `QUICK_DEV_FINAL_REVIEW_RESULT`: "COMPLETE" (default) or "ISSUES FOUND"
+/// - `QUICK_DEV_FINAL_REVIEW_RESULT`: "NO_AMENDMENTS" (default) or "AMENDMENTS"
 pub fn quick_dev_reviewer_mock_script() -> String {
     r###"#!/usr/bin/env bash
 set -euo pipefail
@@ -3475,18 +3475,18 @@ EOF
 Implementation looks good, no changes needed.
 EOF
   fi
-elif grep -q "quick-dev final review pass" <<< "$INPUT"; then
-  result="${QUICK_DEV_FINAL_REVIEW_RESULT:-COMPLETE}"
-  if [ "$result" = "ISSUES FOUND" ]; then
+elif grep -q "final reviewer auditing" <<< "$INPUT"; then
+  result="${QUICK_DEV_FINAL_REVIEW_RESULT:-NO_AMENDMENTS}"
+  if [ "$result" = "AMENDMENTS" ]; then
     cat <<'EOF'
-# Final Review: ISSUES FOUND
+# Final Review: AMENDMENTS
 
 ## Issues
 - Mock issue found by reviewer final review.
 EOF
   else
     cat <<'EOF'
-# Final Review: COMPLETE
+# Final Review: NO AMENDMENTS
 
 ## Summary
 All requirements met per reviewer review.
@@ -3515,9 +3515,9 @@ if grep -q "quick-dev reviewer" <<< "$INPUT"; then
 ## Required Changes
 - Always-reject mock: changes requested every time.
 EOF
-elif grep -q "quick-dev final review pass" <<< "$INPUT"; then
+elif grep -q "final reviewer auditing" <<< "$INPUT"; then
   cat <<'EOF'
-# Final Review: COMPLETE
+# Final Review: NO AMENDMENTS
 
 ## Summary
 Force-approved after iteration guard.
@@ -3558,9 +3558,9 @@ EOF
 - Fix the initial implementation issue.
 EOF
   fi
-elif grep -q "quick-dev final review pass" <<< "$INPUT"; then
+elif grep -q "final reviewer auditing" <<< "$INPUT"; then
   cat <<'EOF'
-# Final Review: COMPLETE
+# Final Review: NO AMENDMENTS
 
 ## Summary
 All requirements met.
@@ -3573,8 +3573,8 @@ fi
     .to_owned()
 }
 
-/// Quick-dev final-review mock that returns ISSUES FOUND on the first call,
-/// then COMPLETE on subsequent calls. Used to test the final-review reloop.
+/// Quick-dev final-review mock that returns AMENDMENTS on the first call,
+/// then NO AMENDMENTS on subsequent calls. Used to test the final-review reloop.
 ///
 /// Set `QUICK_DEV_FR_STATE_FILE` to a path for the state file.
 pub fn quick_dev_final_review_issues_once_script() -> String {
@@ -3616,7 +3616,7 @@ elif grep -q "quick-dev reviewer" <<< "$INPUT"; then
 ## Summary
 Implementation satisfactory.
 EOF
-elif grep -q "quick-dev final review pass" <<< "$INPUT"; then
+elif grep -q "final reviewer auditing" <<< "$INPUT"; then
   count=0
   if [ -f "$STATE" ]; then
     count="$(cat "$STATE")"
@@ -3625,14 +3625,14 @@ elif grep -q "quick-dev final review pass" <<< "$INPUT"; then
   echo "$count" > "$STATE"
   if [ "$count" -le 2 ]; then
     cat <<'EOF'
-# Final Review: ISSUES FOUND
+# Final Review: AMENDMENTS
 
 ## Issues
 - Mock issue requiring re-implementation.
 EOF
   else
     cat <<'EOF'
-# Final Review: COMPLETE
+# Final Review: NO AMENDMENTS
 
 ## Summary
 All requirements met after reloop.
@@ -3686,9 +3686,9 @@ elif grep -q "quick-dev reviewer" <<< "$INPUT"; then
 ## Summary
 OK.
 EOF
-elif grep -q "quick-dev final review pass" <<< "$INPUT"; then
+elif grep -q "final reviewer auditing" <<< "$INPUT"; then
   cat <<'EOF'
-# Final Review: ISSUES FOUND
+# Final Review: AMENDMENTS
 
 ## Issues
 - Always-issues mock: perpetual issues found.
@@ -3763,18 +3763,18 @@ EOF
   # Create more stray files on second iteration
   echo "stray notes 2" > 20260304130000-impl-notes.md
   echo "stray response 2" > 20260304130000-impl-response-002.md
-elif grep -q "quick-dev final review pass" <<< "$INPUT"; then
-  result="${QUICK_DEV_FINAL_REVIEW_RESULT:-COMPLETE}"
-  if [ "$result" = "ISSUES FOUND" ]; then
+elif grep -q "final reviewer auditing" <<< "$INPUT"; then
+  result="${QUICK_DEV_FINAL_REVIEW_RESULT:-NO_AMENDMENTS}"
+  if [ "$result" = "AMENDMENTS" ]; then
     cat <<'EOF'
-# Final Review: ISSUES FOUND
+# Final Review: AMENDMENTS
 
 ## Issues
 - Mock issue found by implementer final review.
 EOF
   else
     cat <<'EOF'
-# Final Review: COMPLETE
+# Final Review: NO AMENDMENTS
 
 ## Summary
 All requirements met per implementer review.

--- a/src/validate/tests_quick_dev.rs
+++ b/src/validate/tests_quick_dev.rs
@@ -296,8 +296,8 @@ fn review_loop_changes_requested(h: &RalphHarness) -> TestResult {
 }
 
 /// Final review reloop: first FinalReview finds issues (both backends return
-/// ISSUES FOUND for the first 2 calls), causing a transition back to
-/// PlanAndImplement. Second time through, FinalReview both return COMPLETE.
+/// AMENDMENTS for the first 2 calls), causing a transition back to
+/// PlanAndImplement. Second time through, FinalReview both return NO AMENDMENTS.
 fn final_review_reloop(h: &RalphHarness) -> TestResult {
     run_case(|| {
         let project_id = "qd-fr-reloop-001";

--- a/src/validate/tests_stray_cleanup.rs
+++ b/src/validate/tests_stray_cleanup.rs
@@ -216,18 +216,18 @@ elif grep -q "quick-dev apply-fixes phase" <<< "$INPUT"; then
 EOF
   echo "quick-dev-fixed" >> mock_file.txt
   git add mock_file.txt
-elif grep -q "quick-dev final review pass" <<< "$INPUT"; then
-  result="${QUICK_DEV_FINAL_REVIEW_RESULT:-COMPLETE}"
-  if [ "$result" = "ISSUES FOUND" ]; then
+elif grep -q "final reviewer auditing" <<< "$INPUT"; then
+  result="${QUICK_DEV_FINAL_REVIEW_RESULT:-NO_AMENDMENTS}"
+  if [ "$result" = "AMENDMENTS" ]; then
     cat <<'EOF'
-# Final Review: ISSUES FOUND
+# Final Review: AMENDMENTS
 
 ## Issues
 - Mock issue.
 EOF
   else
     cat <<'EOF'
-# Final Review: COMPLETE
+# Final Review: NO AMENDMENTS
 
 ## Summary
 All requirements met.

--- a/src/workflow/parser.rs
+++ b/src/workflow/parser.rs
@@ -209,10 +209,10 @@ pub fn parse_quick_final_review_output(raw: &str) -> Result<QuickFinalReviewDeci
     };
 
     match first_h1.trim() {
-        "# Final Review: COMPLETE" => Ok(QuickFinalReviewDecision::Complete { body }),
-        "# Final Review: ISSUES FOUND" => Ok(QuickFinalReviewDecision::IssuesFound { body }),
+        "# Final Review: NO AMENDMENTS" => Ok(QuickFinalReviewDecision::Complete { body }),
+        "# Final Review: AMENDMENTS" => Ok(QuickFinalReviewDecision::IssuesFound { body }),
         other => Err(RalphError::ParseError(format!(
-            "unsupported quick final review H1: {other}; expected '# Final Review: COMPLETE' or '# Final Review: ISSUES FOUND'"
+            "unsupported quick final review H1: {other}; expected '# Final Review: NO AMENDMENTS' or '# Final Review: AMENDMENTS'"
         ))),
     }
 }
@@ -1036,14 +1036,14 @@ mod tests {
 
     #[test]
     fn parses_quick_final_review_complete() {
-        let text = "# Final Review: COMPLETE\n\nAll done.";
+        let text = "# Final Review: NO AMENDMENTS\n\nAll done.";
         let parsed = parse_quick_final_review_output(text).expect("parse should succeed");
         assert!(matches!(parsed, QuickFinalReviewDecision::Complete { .. }));
     }
 
     #[test]
     fn parses_quick_final_review_issues_found() {
-        let text = "# Final Review: ISSUES FOUND\n\nNeed additional fixes.";
+        let text = "# Final Review: AMENDMENTS\n\nNeed additional fixes.";
         let parsed = parse_quick_final_review_output(text).expect("parse should succeed");
         assert!(matches!(
             parsed,
@@ -1063,7 +1063,7 @@ mod tests {
 
     #[test]
     fn quick_final_review_parser_rejects_wrong_h1() {
-        let result = parse_quick_final_review_output("# Final Review: NO AMENDMENTS");
+        let result = parse_quick_final_review_output("# Final Review: COMPLETE");
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -1073,7 +1073,7 @@ mod tests {
 
     #[test]
     fn quick_final_review_parser_tolerates_trailing_whitespace() {
-        let text = "# Final Review: COMPLETE   \n\ndone";
+        let text = "# Final Review: NO AMENDMENTS   \n\ndone";
         let parsed =
             parse_quick_final_review_output(text).expect("trailing whitespace should parse");
         assert!(matches!(parsed, QuickFinalReviewDecision::Complete { .. }));
@@ -1081,7 +1081,7 @@ mod tests {
 
     #[test]
     fn quick_final_review_parser_tolerates_leading_whitespace() {
-        let text = "  # Final Review: ISSUES FOUND  \n\nbug";
+        let text = "  # Final Review: AMENDMENTS  \n\nbug";
         let parsed =
             parse_quick_final_review_output(text).expect("leading whitespace on H1 should parse");
         assert!(matches!(
@@ -1092,7 +1092,7 @@ mod tests {
 
     #[test]
     fn quick_final_review_parser_strips_frontmatter() {
-        let text = "---\nartifact: final\n---\n# Final Review: ISSUES FOUND\n\nbug";
+        let text = "---\nartifact: final\n---\n# Final Review: AMENDMENTS\n\nbug";
         let parsed = parse_quick_final_review_output(text).expect("frontmatter should be stripped");
         assert!(matches!(
             parsed,

--- a/src/workflow/quick_dev_orchestrator.rs
+++ b/src/workflow/quick_dev_orchestrator.rs
@@ -25,8 +25,9 @@ use crate::project::load_project_config_if_exists;
 use crate::project::state::{Phase, ProjectState, ProjectStatus, QuickDevPhase};
 use crate::prompts::quick_dev::{
     build_quick_dev_apply_fixes_prompt, build_quick_dev_codex_review_prompt,
-    build_quick_dev_final_review_prompt, build_quick_dev_plan_implement_prompt,
+    build_quick_dev_plan_implement_prompt,
 };
+use crate::prompts::templates::{default_final_reviewer_template, render_template_with_fallback};
 use crate::util::lock::ProjectLock;
 use crate::workflow::parser::{
     parse_codex_review_output, parse_quick_final_review_output, CodexReviewDecision,
@@ -678,18 +679,11 @@ impl QuickDevOrchestrator {
                         final_review_attempts, "quick-dev: FinalReview phase"
                     );
 
-                    let git_diff = current_git_diff(&self.workspace.root)?;
-
                     // Two sequential independent calls (implementer then reviewer)
                     // Each with fresh context (no session reuse)
 
                     // --- Implementer final review ---
-                    let impl_final_prompt = build_final_review_prompt(
-                        effective,
-                        &prompt_content,
-                        &spec_content,
-                        &git_diff,
-                    )?;
+                    let impl_final_prompt = build_final_review_prompt(effective, &prompt_content)?;
                     let impl_backend =
                         registry.get_or_create_for_role(implementer_spec, "implementer")?;
                     let mut impl_fr_log = LogWriter::open(
@@ -732,12 +726,7 @@ impl QuickDevOrchestrator {
                     )?;
 
                     // --- Reviewer final review (fresh context) ---
-                    let rev_final_prompt = build_final_review_prompt(
-                        effective,
-                        &prompt_content,
-                        &spec_content,
-                        &git_diff,
-                    )?;
+                    let rev_final_prompt = build_final_review_prompt(effective, &prompt_content)?;
                     let rev_backend = registry.get_or_create_for_role(reviewer_spec, "reviewer")?;
                     let mut rev_fr_log = LogWriter::open(
                         log_dir,
@@ -1226,21 +1215,26 @@ fn build_apply_fixes_prompt(
     build_quick_dev_apply_fixes_prompt(&effective.templates.quick_dev_apply_fixes, &vars)
 }
 
-fn build_final_review_prompt(
-    effective: &EffectiveConfig,
-    prompt_content: &str,
-    spec_content: &str,
-    git_diff: &str,
-) -> Result<String> {
+fn build_final_review_prompt(effective: &EffectiveConfig, prompt_content: &str) -> Result<String> {
     let mut vars = BTreeMap::new();
     vars.insert(
         "system_guardrails".to_owned(),
         QUICK_DEV_REVIEWER_GUARDRAILS.to_owned(),
     );
-    vars.insert("feature_spec".to_owned(), spec_content.to_owned());
     vars.insert("master_prompt".to_owned(), prompt_content.to_owned());
-    vars.insert("current_diff".to_owned(), git_diff.to_owned());
-    build_quick_dev_final_review_prompt(&effective.templates.quick_dev_final_review, &vars)
+    let mut prompt = render_template_with_fallback(
+        &effective.templates.final_reviewer,
+        &vars,
+        default_final_reviewer_template(),
+    )?;
+    // The default final reviewer template only uses {{system_guardrails}}.
+    // Append the master prompt if the template didn't already reference it.
+    let template_src = default_final_reviewer_template();
+    if !template_src.contains("{{master_prompt}}") && !prompt_content.is_empty() {
+        prompt.push_str("\n\n## Master Prompt\n\n");
+        prompt.push_str(prompt_content);
+    }
+    Ok(prompt)
 }
 
 // ---------------------------------------------------------------------------
@@ -1718,7 +1712,6 @@ mod tests {
                 quick_dev_plan_implement: PathBuf::new(),
                 quick_dev_codex_review: PathBuf::new(),
                 quick_dev_apply_fixes: PathBuf::new(),
-                quick_dev_final_review: PathBuf::new(),
                 planner_position: PathBuf::new(),
                 vote: PathBuf::new(),
                 arbiter: PathBuf::new(),

--- a/tests/quick_dev_orchestrator.rs
+++ b/tests/quick_dev_orchestrator.rs
@@ -125,26 +125,26 @@ if [[ "$prompt" == *"final review"* ]] || [[ "$prompt" == *"Final Review"* ]] ||
         echo "$count" > "$counter_file"
         if [[ $count -ge 2 ]]; then
             cat <<'EOF'
-# Final Review: COMPLETE
+# Final Review: NO AMENDMENTS
 
 All requirements are met from implementer perspective.
 EOF
         else
             cat <<'EOF'
-# Final Review: ISSUES FOUND
+# Final Review: AMENDMENTS
 
 Implementation has issues that need addressing.
 EOF
         fi
     elif [[ "$mode" == "issues_found" ]]; then
         cat <<'EOF'
-# Final Review: ISSUES FOUND
+# Final Review: AMENDMENTS
 
 Implementation has issues that need addressing.
 EOF
     else
         cat <<'EOF'
-# Final Review: COMPLETE
+# Final Review: NO AMENDMENTS
 
 All requirements are met from implementer perspective.
 EOF
@@ -186,26 +186,26 @@ if [[ "$prompt" == *"final review"* ]] || [[ "$prompt" == *"Final Review"* ]] ||
         echo "$count" > "$counter_file"
         if [[ $count -ge 2 ]]; then
             cat <<'EOF'
-# Final Review: COMPLETE
+# Final Review: NO AMENDMENTS
 
 All requirements are met.
 EOF
         else
             cat <<'EOF'
-# Final Review: ISSUES FOUND
+# Final Review: AMENDMENTS
 
 Missing test coverage for edge cases.
 EOF
         fi
     elif [[ "$mode" == "issues_found" ]]; then
         cat <<'EOF'
-# Final Review: ISSUES FOUND
+# Final Review: AMENDMENTS
 
 Missing test coverage for edge cases.
 EOF
     else
         cat <<'EOF'
-# Final Review: COMPLETE
+# Final Review: NO AMENDMENTS
 
 All requirements are met.
 EOF
@@ -684,9 +684,9 @@ async fn max_final_review_retries_guard_force_completes() {
 
 #[tokio::test]
 async fn final_review_reloop_then_complete() {
-    // First final review: both say ISSUES FOUND (implementer: issues, reviewer: issues)
+    // First final review: both say AMENDMENTS (implementer: issues, reviewer: issues)
     // After reloop through PlanAndImplement -> CodexReview(satisfied) -> FinalReview:
-    // Second final review: both say COMPLETE
+    // Second final review: both say NO AMENDMENTS
     let (_temp, workspace_root, project_id) =
         setup_quick_dev_workspace("satisfied", "loop_then_complete");
 
@@ -1041,7 +1041,7 @@ fi
 # Check if this is a final review prompt
 if [[ "$prompt" == *"final review"* ]] || [[ "$prompt" == *"Final Review"* ]] || [[ "$prompt" == *"final-review"* ]]; then
     cat <<'EOF'
-# Final Review: COMPLETE
+# Final Review: NO AMENDMENTS
 
 All requirements are met from implementer perspective.
 EOF


### PR DESCRIPTION
## Summary
- Quick-dev final review now uses the same `default_final_reviewer_template()` as the full workflow instead of a thin custom prompt
- Aligns quick-dev parser H1 headings to `NO AMENDMENTS`/`AMENDMENTS` (matching full workflow)
- Removes the `quick_dev_final_review` config/template path since it's no longer needed
- Removes diff injection from final review prompt — reviewers use their tools to inspect the codebase

## Motivation
The codex bot caught a P2 (over-broad `remove_stray_impl_artifacts` call-site) that the quick-dev final reviewers missed because their prompt was a thin "verify completeness" check. The full workflow template already has battle-tested instructions for call-site tracing, concurrency auditing, and correctness checks. Rather than maintaining two diverging prompts, unify them.

## Test plan
- [x] All 1,233 unit/integration tests pass
- [x] All 354 nix build conformance tests pass
- [x] Updated mock scripts to match on new template text
- [x] Parser tests updated for new H1 format

🤖 Generated with [Claude Code](https://claude.com/claude-code)