### PR TITLE
config: increase default quick-dev max_final_review_retries from 2 to 15

### DIFF
--- a/src/workflow/quick_dev_orchestrator.rs
+++ b/src/workflow/quick_dev_orchestrator.rs
@@ -52,7 +52,7 @@ pub struct QuickDevRunOptions {
 }
 
 const DEFAULT_MAX_REVIEW_ITERATIONS: u32 = 5;
-const DEFAULT_MAX_FINAL_REVIEW_RETRIES: u32 = 2;
+const DEFAULT_MAX_FINAL_REVIEW_RETRIES: u32 = 15;
 
 #[derive(Debug, Clone)]
 pub struct OrchestrationResult {
@@ -1501,7 +1501,7 @@ mod tests {
     #[test]
     fn default_max_values() {
         assert_eq!(DEFAULT_MAX_REVIEW_ITERATIONS, 5);
-        assert_eq!(DEFAULT_MAX_FINAL_REVIEW_RETRIES, 2);
+        assert_eq!(DEFAULT_MAX_FINAL_REVIEW_RETRIES, 15);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Increase `DEFAULT_MAX_FINAL_REVIEW_RETRIES` from 2 to 15 for quick-dev workflow
- 2 retries was too low — final reviewers finding legitimate issues would trigger force-complete before the implementation had a chance to converge

🤖 Generated with [Claude Code](https://claude.com/claude-code)