### PR TITLE
fix: require impl_notes in post-amendment loop before allowing completion

### DIFF
--- a/src/workflow/orchestrator.rs
+++ b/src/workflow/orchestrator.rs
@@ -655,8 +655,9 @@ impl Orchestrator {
                         PlannerDecision::CompletionRequest { body } => {
                             // Guard: fail if planner requests completion with unaddressed
                             // final review amendments from the most recent completion loop.
-                            // Only triggers for the immediate bad transition (restart → completion
-                            // without an intervening feature loop to address amendments).
+                            // Requires an intervening feature loop that actually reached
+                            // implementation (has impl_notes), not just a spec-only loop
+                            // from a crash/resume.
                             if let Some(last_attempt) = state.completion_attempts.last() {
                                 let has_restart = resolve_artifact_path_by_suffix(
                                     &project_dir,
@@ -665,11 +666,14 @@ impl Orchestrator {
                                     "final-review-exit-restart.md",
                                 )?
                                 .is_some();
-                                let has_feature_after = state
+                                let has_completed_feature_after = state
                                     .loops
                                     .iter()
-                                    .any(|l| l.loop_number > last_attempt.loop_number);
-                                if has_restart && !has_feature_after {
+                                    .any(|l| {
+                                        l.loop_number > last_attempt.loop_number
+                                            && l.artifacts.impl_notes.is_some()
+                                    });
+                                if has_restart && !has_completed_feature_after {
                                     return Err(RalphError::Orchestration(
                                         "planner requested completion without addressing final review amendments"
                                             .to_owned(),


### PR DESCRIPTION
## Summary
- Addresses Codex review comment on #162: the amendment guard now verifies the intervening feature loop actually reached implementation (`impl_notes.is_some()`), not just that it exists
- Prevents a spec-only loop from a crash/resume from bypassing the guard

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes (all 1233 tests)
- [x] `nix build` passes (354 conformance tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)