### PR TITLE
Remove defensive qualification rules from final reviewer prompt

### DIFF
--- a/src/prompts/templates.rs
+++ b/src/prompts/templates.rs
@@ -398,18 +398,6 @@ pub fn default_final_reviewer_template() -> &'static str {
 
 You have full access to the project codebase via your tools (file reading, search, shell commands). The specification and plan are already committed to git — do NOT rely on a separate spec document. Instead, read the actual source code.
 
-## WHEN TO FLAG AN ISSUE
-
-Only flag an issue as an amendment when ALL of the following are true:
-
-1. It meaningfully impacts correctness, performance, security, or maintainability — not a style preference.
-2. It is discrete and actionable: a developer can read the amendment and know exactly what to change.
-3. The required level of rigor matches the norms already established in this codebase (do not impose stricter standards than the project uses).
-4. It was introduced or exposed by the project's changes, not a pre-existing issue in upstream or vendored code.
-5. It does not rely on unstated assumptions about the runtime environment, deployment target, or usage patterns.
-6. The affected code paths can be provably identified via source reading or tool execution — not speculative.
-7. It is not an intentional, documented design choice (check comments, commit messages, or spec before flagging).
-
 ## HOW TO WRITE AMENDMENT BODIES
 
 - Cite specific files, line numbers, and function names.
@@ -419,10 +407,7 @@ Only flag an issue as an amendment when ALL of the following are true:
 - State the required reproduction scenario or failing condition.
 - Use matter-of-fact tone — no hedging, no rhetorical questions.
 - Each amendment must be immediately graspable by a developer unfamiliar with the review history.
-
-## HOW MANY AMENDMENTS
-
-Output all findings that pass the qualification rules above. If nothing would definitely be fixed by a competent developer reviewing this code, prefer NO AMENDMENTS — do not manufacture findings.
+- Do not manufacture findings — but do not suppress real ones either.
 
 ## PRIORITY LEVELS
 
@@ -444,7 +429,7 @@ Output all findings that pass the qualification rules above. If nothing would de
 
 1. Run `{{review_diff_command}}` to see all source changes relative to `{{base_branch}}`, then read key files to review them.
 2. Read key implementation files and tests end-to-end — do not rely only on the diff.
-3. Apply the qualification rules above to each potential finding.
+3. For each potential finding, verify it against the actual source code.
 4. Produce your output in the format below.
 
 CRITICAL FORMAT REQUIREMENTS:

--- a/src/workflow/quick_dev_orchestrator.rs
+++ b/src/workflow/quick_dev_orchestrator.rs
@@ -1227,7 +1227,7 @@ fn build_final_review_prompt(
     let mut vars = BTreeMap::new();
     vars.insert(
         "system_guardrails".to_owned(),
-        QUICK_DEV_REVIEWER_GUARDRAILS.to_owned(),
+        QUICK_DEV_FINAL_REVIEWER_GUARDRAILS.to_owned(),
     );
     vars.insert("master_prompt".to_owned(), prompt_content.to_owned());
 
@@ -1290,8 +1290,14 @@ const QUICK_DEV_IMPLEMENTER_GUARDRAILS: &str = r#"- Keep edits scoped to this lo
 - If a required change is already satisfied, cite concrete evidence (files/tests) instead of unrelated edits."#;
 
 const QUICK_DEV_REVIEWER_GUARDRAILS: &str = r#"- Treat `.ralph/**` as orchestration runtime state; it is out of scope for feature review.
-- Focus on acceptance criteria and actual behavior, not whether code was first introduced in this loop.
-- If criteria are already satisfied and no code change is required, return the satisfied verdict with evidence."#;
+- Focus on acceptance criteria and actual behavior, not whether code was first introduced in this loop."#;
+
+const QUICK_DEV_FINAL_REVIEWER_GUARDRAILS: &str = r#"- You have full access to the codebase. Use your tools to read files, run git commands, and explore the source code.
+- Do a broad, open-ended code review. Do not limit yourself to any specific category of issues — look for anything that is wrong, unsafe, or broken.
+- Evaluate project-wide outcomes against the master prompt.
+- Treat `.ralph/**` as orchestration runtime state; it is out of scope for feature review.
+- Propose only concrete, high-signal amendments with clear affected files and priority tags (`[P0]`–`[P3]`).
+- One amendment per discrete, actionable issue."#;
 
 // ---------------------------------------------------------------------------
 // Tests


### PR DESCRIPTION
## Summary
- Remove the 7 defensive "WHEN TO FLAG AN ISSUE" qualification rules from the final reviewer template that biased toward NO AMENDMENTS
- Remove "prefer NO AMENDMENTS — do not manufacture findings" instruction
- Remove "return the satisfied verdict with evidence" from quick-dev reviewer guardrails
- Add dedicated `QUICK_DEV_FINAL_REVIEWER_GUARDRAILS` with aggressive review posture ("broad, open-ended code review", "look for anything that is wrong, unsafe, or broken") matching the regular orchestrator

## Motivation
The Codex PR reviewer consistently catches real bugs (e.g. missing pre-commit feedback integration, over-broad cleanup call-site) that the in-loop final reviewer misses across 5+ review rounds. Root cause: the final reviewer template had qualification rules that filtered out valid findings — rules like "does not rely on unstated assumptions" and "provably identified via source reading — not speculative" effectively prevented flagging missing integrations (absent data flows between independently correct subsystems). The guardrails also explicitly instructed "return the satisfied verdict with evidence", biasing toward approval.

## Test plan
- [x] `nix develop -c cargo check` compiles
- [x] `nix develop -c cargo test` passes
- [x] `nix build` — 382 tests pass, binary builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)