### PR TITLE
Fix: defer waiting-feedback label until questions are posted in PRD flow

### DIFF
--- a/src/daemon/interactive_prd.rs
+++ b/src/daemon/interactive_prd.rs
@@ -991,8 +991,6 @@ fn transition_pending_to_awaiting_answers(
 
     eprintln!("prd: attempting Pending->AwaitingAnswers for {owner}/{repo}#{issue_number}");
 
-    ensure_waiting_feedback_label(config, issue_number, &issue.labels);
-
     let result = get_or_fetch_bot_login(config, bot_login_cache)
         .and_then(|bot_login| do_pending_to_awaiting(config, issue, state, &bot_login));
     finish_transition(config, state, result, bot_login_cache)
@@ -1118,7 +1116,10 @@ fn do_pending_to_awaiting(
         }
     };
 
-    // 5. Update and persist state
+    // 5. Add waiting-feedback label only after questions are posted
+    ensure_waiting_feedback_label(config, issue_number, &issue.labels);
+
+    // 6. Update and persist state
     state.state = PrdWorkflowState::AwaitingAnswers;
     state.question_revision = next_revision;
     state.questions_comment_id = comment_id;

--- a/tests/daemon_interactive_prd.rs
+++ b/tests/daemon_interactive_prd.rs
@@ -2034,6 +2034,14 @@ esac; exit 0
         label_raw.contains("ralph:prd-failed"),
         "ralph:prd-failed label should be added: {label_raw}"
     );
+
+    // waiting-feedback must NOT be *added* when bot-login fails before questions
+    // are posted (the label should only appear after questions are successfully
+    // posted to the issue). The --remove-label variant is fine (cleanup on failure).
+    assert!(
+        !label_raw.contains("--add-label ralph:waiting-feedback"),
+        "ralph:waiting-feedback must not be added before questions are posted: {label_raw}"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

In the PRD flow, `ensure_waiting_feedback_label` was called at the top of `transition_pending_to_awaiting_answers` — before bot-login resolution and question generation. If the backend was slow (3600s timeout) or failed, the issue showed `ralph:waiting-feedback` with no questions comment, confusing users.

## Fix

Move `ensure_waiting_feedback_label` from the top of the transition function into `do_pending_to_awaiting`, after questions are successfully posted. The label now only appears once there are actual questions to respond to.

The `AwaitingAnswers` and `AwaitingFeedback` transitions still reconcile the label before their work — which is correct since questions are already posted by that point.

## Test

Added assertion in `pending_bot_login_failure_exhaustion_transitions_to_failed` verifying that `--add-label ralph:waiting-feedback` is NOT issued when bot-login fails before questions are posted.

- [x] 386 tests pass
- [x] `nix build` succeeds