### PR TITLE
refactor: convert daemon subsystem from sync to async

### DIFF
--- a/src/cli/daemon.rs
+++ b/src/cli/daemon.rs
@@ -8,7 +8,7 @@ use crate::config::{resolve_daemon_config, validate_effective_daemon_config};
 use crate::daemon::bootstrap;
 use crate::daemon::github;
 use crate::daemon::rebase_agent;
-use crate::daemon::runtime::{retrigger_failed_task, spawn_blocking_op, DaemonRuntimeConfig};
+use crate::daemon::runtime::{retrigger_failed_task, DaemonRuntimeConfig};
 use crate::project::load_project_config_if_exists;
 use crate::util::lock::DaemonLock;
 use crate::workspace::Workspace;
@@ -84,15 +84,9 @@ pub struct DaemonRetriggerArgs {
 pub async fn execute(args: DaemonArgs) -> Result<()> {
     match args.command {
         DaemonCommand::Start(start_args) => execute_start(start_args).await,
-        DaemonCommand::Status(status_args) => {
-            spawn_blocking_op(move || execute_status(status_args)).await
-        }
-        DaemonCommand::Abort(abort_args) => {
-            spawn_blocking_op(move || execute_abort(abort_args)).await
-        }
-        DaemonCommand::Retrigger(retrigger_args) => {
-            spawn_blocking_op(move || execute_retrigger(retrigger_args)).await
-        }
+        DaemonCommand::Status(status_args) => execute_status(status_args).await,
+        DaemonCommand::Abort(abort_args) => execute_abort(abort_args).await,
+        DaemonCommand::Retrigger(retrigger_args) => execute_retrigger(retrigger_args).await,
     }
 }
 
@@ -182,10 +176,10 @@ async fn execute_start(args: DaemonStartArgs) -> Result<()> {
         preflight_check_gh(&gh_bin)?;
 
         // Ensure lifecycle labels exist (best-effort, non-blocking)
-        github::ensure_labels_best_effort_with_gh_bin(&gh_bin, &owner, &repo_name);
+        github::ensure_labels_best_effort_with_gh_bin(&gh_bin, &owner, &repo_name).await;
 
         // Ensure PRD lifecycle labels exist (best-effort, non-blocking)
-        github::ensure_prd_labels_best_effort_with_gh_bin(&gh_bin, &owner, &repo_name);
+        github::ensure_prd_labels_best_effort_with_gh_bin(&gh_bin, &owner, &repo_name).await;
 
         // Load project config if an active project exists
         let project_config = match workspace.active_project_id() {
@@ -307,7 +301,7 @@ async fn execute_start(args: DaemonStartArgs) -> Result<()> {
 }
 
 /// Status: query GitHub labels to show current issue lifecycle state.
-fn execute_status(args: DaemonStatusArgs) -> Result<()> {
+async fn execute_status(args: DaemonStatusArgs) -> Result<()> {
     let repos = if args.repo.is_empty() {
         // Scan data-dir for owner/repo directories
         scan_repo_slugs(&args.data_dir)?
@@ -338,7 +332,7 @@ fn execute_status(args: DaemonStatusArgs) -> Result<()> {
         let mut seen: std::collections::HashSet<u32> = std::collections::HashSet::new();
         for label in &["ralph:ready", "ralph:in-progress"] {
             let query_labels = vec![label.to_string()];
-            match github::poll_issues(&owner, &repo_name, &query_labels) {
+            match github::poll_issues(&owner, &repo_name, &query_labels).await {
                 Ok((batch, _overflow)) => {
                     for issue in batch {
                         if seen.insert(issue.number) {
@@ -381,7 +375,7 @@ fn execute_status(args: DaemonStatusArgs) -> Result<()> {
 }
 
 /// Abort: kill child (if running locally) and swap label to `ralph:failed`.
-fn execute_abort(args: DaemonAbortArgs) -> Result<()> {
+async fn execute_abort(args: DaemonAbortArgs) -> Result<()> {
     let issue_number: u32 = args.issue_number.parse().map_err(|_| {
         RalphError::Validation(format!("invalid issue number: {}", args.issue_number))
     })?;
@@ -392,7 +386,7 @@ fn execute_abort(args: DaemonAbortArgs) -> Result<()> {
     let (owner, repo_name) = parse_repo_slug(&slug)?;
 
     // Verify the issue is currently in-progress
-    let labels = github::fetch_issue_labels(&owner, &repo_name, issue_number)?;
+    let labels = github::fetch_issue_labels(&owner, &repo_name, issue_number).await?;
     let lifecycle = github::classify_lifecycle_labels(&labels);
 
     if !lifecycle.iter().any(|l| l == "ralph:in-progress") {
@@ -403,13 +397,13 @@ fn execute_abort(args: DaemonAbortArgs) -> Result<()> {
     }
 
     // Swap label: in-progress -> failed (no PID info available from CLI)
-    crate::daemon::abort_task_by_labels(&owner, &repo_name, issue_number, None, None)?;
+    crate::daemon::abort_task_by_labels(&owner, &repo_name, issue_number, None, None).await?;
 
     println!("aborted issue {slug}#{issue_number}");
     Ok(())
 }
 
-fn execute_retrigger(args: DaemonRetriggerArgs) -> Result<()> {
+async fn execute_retrigger(args: DaemonRetriggerArgs) -> Result<()> {
     let issue_number: u32 = args.issue_number.parse().map_err(|_| {
         RalphError::Validation(format!("invalid issue number: {}", args.issue_number))
     })?;
@@ -419,7 +413,7 @@ fn execute_retrigger(args: DaemonRetriggerArgs) -> Result<()> {
         .ok_or_else(|| RalphError::Validation("--repo is required for retrigger".to_owned()))?;
     let (owner, repo_name) = parse_repo_slug(&slug)?;
 
-    retrigger_failed_task(&owner, &repo_name, issue_number)?;
+    retrigger_failed_task(&owner, &repo_name, issue_number).await?;
     println!("retriggered issue {slug}#{issue_number}");
     Ok(())
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -299,7 +299,7 @@ pub async fn run(cli: Cli) -> Result<()> {
         Commands::QuickDevRun(args) => quick_dev_run::execute(args).await,
         Commands::QuickDevAuto(args) => quick_dev_auto::execute(args).await,
         Commands::Validate(args) => validate::execute(args),
-        Commands::Status(args) => status::execute(args),
+        Commands::Status(args) => status::execute(args).await,
         Commands::History(args) => history::execute(args),
         Commands::Tail(args) => tail::execute(args).await,
         Commands::Rollback(args) => rollback::execute(args),

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -19,7 +19,7 @@ use crate::workflow::parser::{
 use crate::workspace::Workspace;
 use crate::{error::RalphError, Result};
 
-pub fn execute(args: StatusArgs) -> Result<()> {
+pub async fn execute(args: StatusArgs) -> Result<()> {
     let workspace = Workspace::discover()?;
     let project_id = workspace.resolve_project_id(args.project.as_deref())?;
 
@@ -31,7 +31,7 @@ pub fn execute(args: StatusArgs) -> Result<()> {
     // Position is already derived from checkpoint commits in
     // reconstruct_project_state — no additional remap needed here.
 
-    if let Some(label_status) = derive_project_status_from_labels(&workspace, &project_id) {
+    if let Some(label_status) = derive_project_status_from_labels(&workspace, &project_id).await {
         state.status = label_status;
     }
 
@@ -185,7 +185,7 @@ fn project_status_label(status: &crate::project::state::ProjectStatus) -> &'stat
     }
 }
 
-fn derive_project_status_from_labels(
+async fn derive_project_status_from_labels(
     workspace: &Workspace,
     project_id: &str,
 ) -> Option<ProjectStatus> {
@@ -193,7 +193,7 @@ fn derive_project_status_from_labels(
     let git_context = project_git_context(workspace, project_id)?;
     let (owner, repo) = parse_github_repo_slug(&git_context.repo_root)?;
 
-    let labels = fetch_issue_labels(&owner, &repo, issue_number).ok()?;
+    let labels = fetch_issue_labels(&owner, &repo, issue_number).await.ok()?;
     let lifecycle = classify_lifecycle_labels(&labels);
     if lifecycle.len() > 1 {
         return Some(ProjectStatus::Failed);

--- a/src/daemon/github.rs
+++ b/src/daemon/github.rs
@@ -1,6 +1,5 @@
-use std::process::Command;
-use std::thread;
 use std::time::Duration;
+use tokio::process::Command;
 
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
@@ -89,11 +88,15 @@ pub struct PrMergeInfo {
 ///
 /// Returns `(issues, overflow)` where overflow is true when exactly 100 issues
 /// were returned, indicating possible truncation.
-pub fn poll_issues(owner: &str, repo: &str, labels: &[String]) -> Result<(Vec<GhIssue>, bool)> {
-    poll_issues_with_gh_bin(DEFAULT_GH_BIN, owner, repo, labels)
+pub async fn poll_issues(
+    owner: &str,
+    repo: &str,
+    labels: &[String],
+) -> Result<(Vec<GhIssue>, bool)> {
+    poll_issues_with_gh_bin(DEFAULT_GH_BIN, owner, repo, labels).await
 }
 
-pub fn poll_issues_with_gh_bin(
+pub async fn poll_issues_with_gh_bin(
     gh_bin: &str,
     owner: &str,
     repo: &str,
@@ -121,6 +124,7 @@ pub fn poll_issues_with_gh_bin(
     let output = Command::new(gh_bin)
         .args(&args)
         .output()
+        .await
         .map_err(|err| RalphError::Orchestration(format!("failed to run gh issue list: {err}")))?;
 
     if !output.status.success() {
@@ -157,7 +161,7 @@ pub fn poll_issues_with_gh_bin(
 }
 
 /// Fetch an issue's title/body for restart recovery of legacy daemon tasks.
-pub fn fetch_issue_body(
+pub async fn fetch_issue_body(
     owner: &str,
     repo: &str,
     issue_number: u32,
@@ -174,6 +178,7 @@ pub fn fetch_issue_body(
             "title,body",
         ])
         .output()
+        .await
         .map_err(|err| {
             RalphError::Orchestration(format!("failed to run gh issue view for title/body: {err}"))
         })?;
@@ -196,7 +201,7 @@ pub fn fetch_issue_body(
 }
 
 /// Query PR mergeability/status metadata needed by daemon rebase logic.
-pub fn query_pr_merge_info(owner: &str, repo: &str, pr_number: u32) -> Result<PrMergeInfo> {
+pub async fn query_pr_merge_info(owner: &str, repo: &str, pr_number: u32) -> Result<PrMergeInfo> {
     let full_repo = format!("{owner}/{repo}");
     let output = Command::new("gh")
         .args([
@@ -209,6 +214,7 @@ pub fn query_pr_merge_info(owner: &str, repo: &str, pr_number: u32) -> Result<Pr
             "mergeable,state,baseRefName,headRefOid",
         ])
         .output()
+        .await
         .map_err(|err| RalphError::Orchestration(format!("failed to run gh pr view: {err}")))?;
 
     if !output.status.success() {
@@ -244,7 +250,7 @@ pub fn filter_claimable(issues: Vec<GhIssue>) -> Vec<GhIssue> {
 }
 
 /// Claim an issue by adding the `ralph:in-progress` label.
-pub fn claim_issue(owner: &str, repo: &str, issue_number: u32) -> Result<()> {
+pub async fn claim_issue(owner: &str, repo: &str, issue_number: u32) -> Result<()> {
     let full_repo = format!("{owner}/{repo}");
     let output = Command::new("gh")
         .args([
@@ -257,6 +263,7 @@ pub fn claim_issue(owner: &str, repo: &str, issue_number: u32) -> Result<()> {
             "ralph:in-progress",
         ])
         .output()
+        .await
         .map_err(|err| {
             RalphError::Orchestration(format!("failed to run gh issue edit for claiming: {err}"))
         })?;
@@ -275,7 +282,7 @@ pub fn claim_issue(owner: &str, repo: &str, issue_number: u32) -> Result<()> {
 
 /// Release a previously-claimed issue by removing the `ralph:in-progress`
 /// label.
-pub fn release_claim(owner: &str, repo: &str, issue_number: u32) -> Result<()> {
+pub async fn release_claim(owner: &str, repo: &str, issue_number: u32) -> Result<()> {
     let full_repo = format!("{owner}/{repo}");
     let output = Command::new("gh")
         .args([
@@ -288,6 +295,7 @@ pub fn release_claim(owner: &str, repo: &str, issue_number: u32) -> Result<()> {
             "ralph:in-progress",
         ])
         .output()
+        .await
         .map_err(|err| {
             RalphError::Orchestration(format!(
                 "failed to run gh issue edit for claim release: {err}"
@@ -307,7 +315,12 @@ pub fn release_claim(owner: &str, repo: &str, issue_number: u32) -> Result<()> {
 }
 
 /// Update the title of a GitHub issue.
-pub fn update_issue_title(owner: &str, repo: &str, issue_number: u32, title: &str) -> Result<()> {
+pub async fn update_issue_title(
+    owner: &str,
+    repo: &str,
+    issue_number: u32,
+    title: &str,
+) -> Result<()> {
     let full_repo = format!("{owner}/{repo}");
     let output = Command::new("gh")
         .args([
@@ -320,6 +333,7 @@ pub fn update_issue_title(owner: &str, repo: &str, issue_number: u32, title: &st
             title,
         ])
         .output()
+        .await
         .map_err(|err| {
             RalphError::Orchestration(format!("failed to run gh issue edit --title: {err}"))
         })?;
@@ -337,7 +351,12 @@ pub fn update_issue_title(owner: &str, repo: &str, issue_number: u32, title: &st
 }
 
 /// Update the body of a GitHub issue.
-pub fn update_issue_body(owner: &str, repo: &str, issue_number: u32, body: &str) -> Result<()> {
+pub async fn update_issue_body(
+    owner: &str,
+    repo: &str,
+    issue_number: u32,
+    body: &str,
+) -> Result<()> {
     let full_repo = format!("{owner}/{repo}");
     let output = Command::new("gh")
         .args([
@@ -350,6 +369,7 @@ pub fn update_issue_body(owner: &str, repo: &str, issue_number: u32, body: &str)
             body,
         ])
         .output()
+        .await
         .map_err(|err| {
             RalphError::Orchestration(format!("failed to run gh issue edit --body: {err}"))
         })?;
@@ -367,7 +387,7 @@ pub fn update_issue_body(owner: &str, repo: &str, issue_number: u32, body: &str)
 }
 
 /// Check whether a comment with the given marker already exists on the issue.
-pub fn comment_marker_exists(
+pub async fn comment_marker_exists(
     owner: &str,
     repo: &str,
     issue_number: u32,
@@ -387,6 +407,7 @@ pub fn comment_marker_exists(
             ".comments[].body",
         ])
         .output()
+        .await
         .map_err(|err| {
             RalphError::Orchestration(format!("failed to check issue comments: {err}"))
         })?;
@@ -406,7 +427,7 @@ pub fn comment_marker_exists(
 
 /// Post an idempotent comment on the issue. If a comment with the given marker
 /// already exists, skip posting.
-pub fn post_idempotent_comment(
+pub async fn post_idempotent_comment(
     owner: &str,
     repo: &str,
     issue_number: u32,
@@ -415,7 +436,7 @@ pub fn post_idempotent_comment(
     body_text: &str,
 ) -> Result<()> {
     let marker = format!("<!-- ralph:task:{task_id}:{phase} -->");
-    if comment_marker_exists(owner, repo, issue_number, &marker)? {
+    if comment_marker_exists(owner, repo, issue_number, &marker).await? {
         return Ok(());
     }
 
@@ -432,6 +453,7 @@ pub fn post_idempotent_comment(
             &full_body,
         ])
         .output()
+        .await
         .map_err(|err| {
             RalphError::Orchestration(format!(
                 "failed to post comment on {}#{}: {err}",
@@ -452,7 +474,7 @@ pub fn post_idempotent_comment(
 }
 
 /// Post a comment on a pull request.
-pub fn post_pr_comment(owner: &str, repo: &str, pr_number: u32, body: &str) -> Result<()> {
+pub async fn post_pr_comment(owner: &str, repo: &str, pr_number: u32, body: &str) -> Result<()> {
     let full_repo = format!("{owner}/{repo}");
     let output = Command::new("gh")
         .args([
@@ -465,6 +487,7 @@ pub fn post_pr_comment(owner: &str, repo: &str, pr_number: u32, body: &str) -> R
             body,
         ])
         .output()
+        .await
         .map_err(|err| RalphError::Orchestration(format!("failed to run gh pr comment: {err}")))?;
 
     if !output.status.success() {
@@ -484,16 +507,16 @@ pub fn post_pr_comment(owner: &str, repo: &str, pr_number: u32, body: &str) -> R
 /// This is used when bot identity is unavailable and body-only marker lookup
 /// would be vulnerable to user spoofing.  Callers should include any marker
 /// text in `body` themselves.
-pub fn post_raw_issue_comment(
+pub async fn post_raw_issue_comment(
     owner: &str,
     repo: &str,
     issue_number: u32,
     body: &str,
 ) -> Result<()> {
-    post_raw_issue_comment_with_gh_bin(DEFAULT_GH_BIN, owner, repo, issue_number, body)
+    post_raw_issue_comment_with_gh_bin(DEFAULT_GH_BIN, owner, repo, issue_number, body).await
 }
 
-pub fn post_raw_issue_comment_with_gh_bin(
+pub async fn post_raw_issue_comment_with_gh_bin(
     gh_bin: &str,
     owner: &str,
     repo: &str,
@@ -512,6 +535,7 @@ pub fn post_raw_issue_comment_with_gh_bin(
             body,
         ])
         .output()
+        .await
         .map_err(|err| {
             RalphError::Orchestration(format!(
                 "failed to post raw comment on {full_repo}#{issue_number}: {err}"
@@ -530,13 +554,14 @@ pub fn post_raw_issue_comment_with_gh_bin(
 
 /// Check for an existing PR with the given head branch.
 /// Returns `Some(url)` if found, `None` otherwise.
-pub fn find_existing_pr(owner: &str, repo: &str, branch: &str) -> Result<Option<String>> {
+pub async fn find_existing_pr(owner: &str, repo: &str, branch: &str) -> Result<Option<String>> {
     let full_repo = format!("{owner}/{repo}");
     let output = Command::new("gh")
         .args([
             "pr", "list", "--repo", &full_repo, "--head", branch, "--json", "url", "-q", ".[0].url",
         ])
         .output()
+        .await
         .map_err(|err| RalphError::Orchestration(format!("failed to check existing PRs: {err}")))?;
 
     if !output.status.success() {
@@ -552,7 +577,7 @@ pub fn find_existing_pr(owner: &str, repo: &str, branch: &str) -> Result<Option<
 }
 
 /// Create a pull request. Returns the PR URL on success, or an error.
-pub fn create_pr(
+pub async fn create_pr(
     owner: &str,
     repo: &str,
     branch: &str,
@@ -570,6 +595,7 @@ pub fn create_pr(
     let output = Command::new("gh")
         .args(&args)
         .output()
+        .await
         .map_err(|err| RalphError::Orchestration(format!("failed to create PR: {err}")))?;
 
     if !output.status.success() {
@@ -588,16 +614,17 @@ pub fn create_pr(
 /// exists, otherwise falls back to `detect_base_branch` (which tries
 /// `origin/HEAD`, common default branch names, etc.).  Returns a typed error
 /// when no valid base ref can be resolved.
-pub fn has_commits_ahead_of_base(
+pub async fn has_commits_ahead_of_base(
     worktree_path: &std::path::Path,
     base_branch: &str,
 ) -> Result<bool> {
-    let base = resolve_ahead_base(worktree_path, base_branch)?;
+    let base = resolve_ahead_base(worktree_path, base_branch).await?;
     let range = format!("{base}..HEAD");
     let output = Command::new("git")
         .args(["rev-list", "--count", &range])
         .current_dir(worktree_path)
         .output()
+        .await
         .map_err(|err| {
             RalphError::Orchestration(format!("failed to run git rev-list --count {range}: {err}"))
         })?;
@@ -626,25 +653,30 @@ pub fn has_commits_ahead_of_base(
 /// Tries `origin/{base_branch}` first, then falls back to auto-detection via
 /// `detect_base_branch`.  Returns an error only if no resolvable base ref can
 /// be found at all.
-fn resolve_ahead_base(worktree_path: &std::path::Path, configured_base: &str) -> Result<String> {
+async fn resolve_ahead_base(
+    worktree_path: &std::path::Path,
+    configured_base: &str,
+) -> Result<String> {
     // Try the configured base as a remote ref first.
     let candidate = format!("origin/{configured_base}");
     let check = Command::new("git")
         .args(["rev-parse", "--verify", &candidate])
         .current_dir(worktree_path)
-        .output();
+        .output()
+        .await;
     if check.map(|o| o.status.success()).unwrap_or(false) {
         return Ok(candidate);
     }
 
     // Configured base not found as remote ref — fall back to auto-detection.
-    let detected = detect_base_branch(worktree_path);
+    let detected = detect_base_branch(worktree_path).await;
 
     // Verify the detected ref actually resolves.
     let verify = Command::new("git")
         .args(["rev-parse", "--verify", &detected])
         .current_dir(worktree_path)
-        .output();
+        .output()
+        .await;
     if verify.map(|o| o.status.success()).unwrap_or(false) {
         return Ok(detected);
     }
@@ -656,12 +688,13 @@ fn resolve_ahead_base(worktree_path: &std::path::Path, configured_base: &str) ->
 }
 
 /// Mark a draft pull request as ready for review.
-pub fn mark_pr_ready(owner: &str, repo: &str, pr_number: u32) -> Result<()> {
+pub async fn mark_pr_ready(owner: &str, repo: &str, pr_number: u32) -> Result<()> {
     let full_repo = format!("{owner}/{repo}");
     let pr_number_str = pr_number.to_string();
     let output = Command::new("gh")
         .args(["pr", "ready", &pr_number_str, "--repo", &full_repo])
         .output()
+        .await
         .map_err(|err| {
             RalphError::Orchestration(format!(
                 "failed to run gh pr ready for {full_repo}#{pr_number}: {err}"
@@ -679,7 +712,7 @@ pub fn mark_pr_ready(owner: &str, repo: &str, pr_number: u32) -> Result<()> {
 }
 
 /// Return whether a pull request is currently a draft.
-pub fn is_pr_draft(owner: &str, repo: &str, pr_number: u32) -> Result<bool> {
+pub async fn is_pr_draft(owner: &str, repo: &str, pr_number: u32) -> Result<bool> {
     let full_repo = format!("{owner}/{repo}");
     let pr_number_str = pr_number.to_string();
     let output = Command::new("gh")
@@ -693,6 +726,7 @@ pub fn is_pr_draft(owner: &str, repo: &str, pr_number: u32) -> Result<bool> {
             "isDraft",
         ])
         .output()
+        .await
         .map_err(|err| {
             RalphError::Orchestration(format!(
                 "failed to run gh pr view for draft state on {full_repo}#{pr_number}: {err}"
@@ -711,12 +745,13 @@ pub fn is_pr_draft(owner: &str, repo: &str, pr_number: u32) -> Result<bool> {
 }
 
 /// Close a pull request.
-pub fn close_pr(owner: &str, repo: &str, pr_number: u32) -> Result<()> {
+pub async fn close_pr(owner: &str, repo: &str, pr_number: u32) -> Result<()> {
     let full_repo = format!("{owner}/{repo}");
     let pr_number_str = pr_number.to_string();
     let output = Command::new("gh")
         .args(["pr", "close", &pr_number_str, "--repo", &full_repo])
         .output()
+        .await
         .map_err(|err| {
             RalphError::Orchestration(format!(
                 "failed to run gh pr close for {full_repo}#{pr_number}: {err}"
@@ -737,12 +772,13 @@ pub fn close_pr(owner: &str, repo: &str, pr_number: u32) -> Result<()> {
 ///
 /// Returns `Ok(Some(stat))` on success, `Ok(None)` if the diff stat cannot be
 /// determined (e.g. no merge-base), or `Err` on execution failure.
-pub fn diff_stat(worktree_path: &std::path::Path) -> Result<Option<String>> {
-    let base = detect_base_branch(worktree_path);
+pub async fn diff_stat(worktree_path: &std::path::Path) -> Result<Option<String>> {
+    let base = detect_base_branch(worktree_path).await;
     let output = Command::new("git")
         .args(["diff", "--stat", &format!("{base}...HEAD")])
         .current_dir(worktree_path)
         .output()
+        .await
         .map_err(|err| {
             RalphError::Orchestration(format!("failed to run git diff --stat: {err}"))
         })?;
@@ -761,7 +797,7 @@ pub fn diff_stat(worktree_path: &std::path::Path) -> Result<Option<String>> {
 
 /// Create a pull request using `--body-file` for large body content.
 /// Returns the PR URL on success, or an error.
-pub fn create_pr_with_body_file(
+pub async fn create_pr_with_body_file(
     owner: &str,
     repo: &str,
     branch: &str,
@@ -796,6 +832,7 @@ pub fn create_pr_with_body_file(
     let output = Command::new("gh")
         .args(&args)
         .output()
+        .await
         .map_err(|err| RalphError::Orchestration(format!("failed to create PR: {err}")))?;
 
     if !output.status.success() {
@@ -809,7 +846,7 @@ pub fn create_pr_with_body_file(
 }
 
 /// Edit an existing PR by URL using `--body-file` for large body content.
-pub fn edit_pr(pr_url: &str, title: &str, body_file: &std::path::Path) -> Result<()> {
+pub async fn edit_pr(pr_url: &str, title: &str, body_file: &std::path::Path) -> Result<()> {
     let body_file_str = body_file.to_string_lossy();
     let output = Command::new("gh")
         .args([
@@ -822,6 +859,7 @@ pub fn edit_pr(pr_url: &str, title: &str, body_file: &std::path::Path) -> Result
             &body_file_str,
         ])
         .output()
+        .await
         .map_err(|err| RalphError::Orchestration(format!("failed to edit PR: {err}")))?;
 
     if !output.status.success() {
@@ -850,11 +888,12 @@ pub fn extract_pr_number(pr_url: &str) -> Option<u32> {
 /// Push with `--force-with-lease` from a worktree. Returns `Ok(())` on
 /// success, or an error. The caller can inspect the error message for
 /// lease rejection (see `is_lease_rejection`).
-pub fn push_force_with_lease(worktree_path: &std::path::Path, branch: &str) -> Result<()> {
+pub async fn push_force_with_lease(worktree_path: &std::path::Path, branch: &str) -> Result<()> {
     let output = Command::new("git")
         .args(["push", "--force-with-lease", "origin", branch])
         .current_dir(worktree_path)
         .output()
+        .await
         .map_err(|err| {
             RalphError::Orchestration(format!("failed to run git push --force-with-lease: {err}"))
         })?;
@@ -883,11 +922,12 @@ pub fn is_lease_rejection(error_msg: &str) -> bool {
 /// The orchestrator may switch the worktree to a project-specific branch
 /// (e.g. `ralph/{project_id}`) during `ralph auto`, so the branch may differ
 /// from the one the daemon originally created (`ralph/daemon/{task_id}`).
-pub fn current_branch(worktree_path: &std::path::Path) -> Result<String> {
+pub async fn current_branch(worktree_path: &std::path::Path) -> Result<String> {
     let output = Command::new("git")
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
         .current_dir(worktree_path)
         .output()
+        .await
         .map_err(|err| {
             RalphError::Orchestration(format!("failed to read current branch: {err}"))
         })?;
@@ -903,10 +943,12 @@ pub fn current_branch(worktree_path: &std::path::Path) -> Result<String> {
 }
 
 /// Push the current branch to the remote from a worktree.
-pub fn push_branch(worktree_path: &std::path::Path, branch: &str) -> Result<()> {
-    push_branch_with_git_bin("git", worktree_path, branch).map_err(|stderr| {
-        RalphError::Orchestration(format!("git push failed for branch {branch}: {stderr}"))
-    })
+pub async fn push_branch(worktree_path: &std::path::Path, branch: &str) -> Result<()> {
+    push_branch_with_git_bin("git", worktree_path, branch)
+        .await
+        .map_err(|stderr| {
+            RalphError::Orchestration(format!("git push failed for branch {branch}: {stderr}"))
+        })
 }
 
 /// Determine whether raw `git push` stderr indicates a transient failure that
@@ -1038,11 +1080,11 @@ pub fn is_retryable_push_error(err: &RalphError) -> bool {
 }
 
 /// Push the current branch with bounded retry for transient failures.
-pub fn push_branch_with_retry(worktree_path: &std::path::Path, branch: &str) -> Result<()> {
-    push_branch_with_retry_impl("git", worktree_path, branch, &[10, 20, 40])
+pub async fn push_branch_with_retry(worktree_path: &std::path::Path, branch: &str) -> Result<()> {
+    push_branch_with_retry_impl("git", worktree_path, branch, &[10, 20, 40]).await
 }
 
-fn push_branch_with_retry_impl(
+async fn push_branch_with_retry_impl(
     git_bin: &str,
     worktree_path: &std::path::Path,
     branch: &str,
@@ -1055,7 +1097,7 @@ fn push_branch_with_retry_impl(
         .chain(std::iter::once(0))
         .enumerate()
     {
-        match push_branch_with_git_bin(git_bin, worktree_path, branch) {
+        match push_branch_with_git_bin(git_bin, worktree_path, branch).await {
             Ok(()) => return Ok(()),
             Err(stderr) => {
                 let attempt = attempt_index + 1;
@@ -1069,7 +1111,7 @@ fn push_branch_with_retry_impl(
                     "push-retry: push failed for branch {branch} in {} (attempt {attempt}/{total_attempts}), retrying in {delay_secs}s: {stderr}",
                     worktree_path.display()
                 );
-                thread::sleep(Duration::from_secs(delay_secs));
+                tokio::time::sleep(Duration::from_secs(delay_secs)).await;
             }
         }
     }
@@ -1077,7 +1119,7 @@ fn push_branch_with_retry_impl(
     unreachable!()
 }
 
-fn push_branch_with_git_bin(
+async fn push_branch_with_git_bin(
     git_bin: &str,
     worktree_path: &std::path::Path,
     branch: &str,
@@ -1086,6 +1128,7 @@ fn push_branch_with_git_bin(
         .args(["push", "-u", "origin", branch])
         .current_dir(worktree_path)
         .output()
+        .await
         .map_err(|err| format!("failed to run git push: {err}"))?;
 
     if !output.status.success() {
@@ -1097,11 +1140,12 @@ fn push_branch_with_git_bin(
 }
 
 /// Returns true when the worktree has an `origin` remote configured.
-pub fn has_origin_remote(worktree_path: &std::path::Path) -> Result<bool> {
+pub async fn has_origin_remote(worktree_path: &std::path::Path) -> Result<bool> {
     let output = Command::new("git")
         .args(["remote", "get-url", "origin"])
         .current_dir(worktree_path)
         .output()
+        .await
         .map_err(|err| {
             RalphError::Orchestration(format!("failed to check origin remote: {err}"))
         })?;
@@ -1115,13 +1159,13 @@ pub fn has_origin_remote(worktree_path: &std::path::Path) -> Result<bool> {
 /// then checks for committed changes by comparing the merge-base of the
 /// default branch with the current HEAD. This ensures that committed changes
 /// on the task branch are detected even when the working tree is clean.
-pub fn has_diff(worktree_path: &std::path::Path) -> Result<bool> {
-    has_diff_with_base(worktree_path, None)
+pub async fn has_diff(worktree_path: &std::path::Path) -> Result<bool> {
+    has_diff_with_base(worktree_path, None).await
 }
 
 /// Check whether the task branch has diverged from the given base branch
 /// (or an auto-detected default if `base_branch` is `None`).
-pub fn has_diff_with_base(
+pub async fn has_diff_with_base(
     worktree_path: &std::path::Path,
     base_branch: Option<&str>,
 ) -> Result<bool> {
@@ -1130,6 +1174,7 @@ pub fn has_diff_with_base(
         .args(["diff", "--quiet", "HEAD"])
         .current_dir(worktree_path)
         .status()
+        .await
         .map_err(|err| RalphError::Orchestration(format!("failed to run git diff: {err}")))?;
 
     if !wt_status.success() {
@@ -1146,14 +1191,15 @@ pub fn has_diff_with_base(
             let check = Command::new("git")
                 .args(["rev-parse", "--verify", &candidate])
                 .current_dir(worktree_path)
-                .output();
+                .output()
+                .await;
             if check.map(|o| o.status.success()).unwrap_or(false) {
                 candidate
             } else {
-                detect_base_branch(worktree_path)
+                detect_base_branch(worktree_path).await
             }
         }
-        None => detect_base_branch(worktree_path),
+        None => detect_base_branch(worktree_path).await,
     };
 
     // 3. Compare committed changes: merge-base of base..HEAD
@@ -1161,6 +1207,7 @@ pub fn has_diff_with_base(
         .args(["diff", "--quiet", &format!("{base}...HEAD")])
         .current_dir(worktree_path)
         .output()
+        .await
         .map_err(|err| {
             RalphError::Orchestration(format!("failed to run git diff against base: {err}"))
         })?;
@@ -1188,12 +1235,13 @@ pub fn has_diff_with_base(
 }
 
 /// Try to detect the base/default branch for diff comparison.
-fn detect_base_branch(worktree_path: &std::path::Path) -> String {
+async fn detect_base_branch(worktree_path: &std::path::Path) -> String {
     // Try symbolic-ref of origin/HEAD
     if let Ok(output) = Command::new("git")
         .args(["symbolic-ref", "refs/remotes/origin/HEAD"])
         .current_dir(worktree_path)
         .output()
+        .await
     {
         if output.status.success() {
             let refname = String::from_utf8_lossy(&output.stdout).trim().to_owned();
@@ -1214,7 +1262,8 @@ fn detect_base_branch(worktree_path: &std::path::Path) -> String {
         let check = Command::new("git")
             .args(["rev-parse", "--verify", candidate])
             .current_dir(worktree_path)
-            .output();
+            .output()
+            .await;
         if let Ok(output) = check {
             if output.status.success() {
                 return candidate.to_string();
@@ -1235,7 +1284,7 @@ fn is_invalid_revision_error(stderr_lower: &str) -> bool {
 
 /// Update labels for task completion: remove `ralph:in-progress`, add the
 /// given terminal label.
-pub fn update_terminal_labels_best_effort(
+pub async fn update_terminal_labels_best_effort(
     owner: &str,
     repo: &str,
     issue_number: u32,
@@ -1254,7 +1303,8 @@ pub fn update_terminal_labels_best_effort(
             "--add-label",
             terminal_label,
         ])
-        .output();
+        .output()
+        .await;
 
     match output {
         Ok(output) if output.status.success() => {}
@@ -1279,11 +1329,11 @@ pub fn update_terminal_labels_best_effort(
 ///
 /// This is best-effort and intentionally non-failing: startup must continue
 /// even when label creation fails.
-pub fn ensure_labels_best_effort(owner: &str, repo: &str) {
-    ensure_labels_best_effort_with_gh_bin(DEFAULT_GH_BIN, owner, repo);
+pub async fn ensure_labels_best_effort(owner: &str, repo: &str) {
+    ensure_labels_best_effort_with_gh_bin(DEFAULT_GH_BIN, owner, repo).await;
 }
 
-pub fn ensure_labels_best_effort_with_gh_bin(gh_bin: &str, owner: &str, repo: &str) {
+pub async fn ensure_labels_best_effort_with_gh_bin(gh_bin: &str, owner: &str, repo: &str) {
     let full_repo = format!("{owner}/{repo}");
 
     for (name, color, description) in REQUIRED_LABELS {
@@ -1299,7 +1349,8 @@ pub fn ensure_labels_best_effort_with_gh_bin(gh_bin: &str, owner: &str, repo: &s
                 "--description",
                 description,
             ])
-            .output();
+            .output()
+            .await;
 
         match output {
             Ok(output) if output.status.success() => {}
@@ -1350,7 +1401,7 @@ pub fn classify_lifecycle_labels(labels: &[String]) -> Vec<String> {
 ///
 /// Spec: "If issue has more than one lifecycle label, normalize to only
 /// `ralph:failed` and skip processing this poll cycle."
-pub fn normalize_multi_lifecycle_labels(
+pub async fn normalize_multi_lifecycle_labels(
     owner: &str,
     repo: &str,
     issue_number: u32,
@@ -1365,12 +1416,12 @@ pub fn normalize_multi_lifecycle_labels(
         if label == "ralph:failed" {
             continue;
         }
-        remove_label_with_retry(owner, repo, issue_number, label)?;
+        remove_label_with_retry(owner, repo, issue_number, label).await?;
     }
 
     // Ensure ralph:failed is present
     if !lifecycle_labels.iter().any(|l| l == "ralph:failed") {
-        add_label_with_retry(owner, repo, issue_number, "ralph:failed")?;
+        add_label_with_retry(owner, repo, issue_number, "ralph:failed").await?;
     }
 
     Ok(true)
@@ -1380,24 +1431,29 @@ pub fn normalize_multi_lifecycle_labels(
 ///
 /// Removes `from_label` and adds `to_label`. Both operations are retried
 /// individually with bounded attempts and exponential backoff.
-pub fn swap_lifecycle_label(
+pub async fn swap_lifecycle_label(
     owner: &str,
     repo: &str,
     issue_number: u32,
     from_label: &str,
     to_label: &str,
 ) -> Result<()> {
-    remove_label_with_retry(owner, repo, issue_number, from_label)?;
-    add_label_with_retry(owner, repo, issue_number, to_label)?;
+    remove_label_with_retry(owner, repo, issue_number, from_label).await?;
+    add_label_with_retry(owner, repo, issue_number, to_label).await?;
     Ok(())
 }
 
 /// Add a label with retry-on-conflict/transient-failure behavior.
-pub fn add_label_with_retry(owner: &str, repo: &str, issue_number: u32, label: &str) -> Result<()> {
-    add_label_with_retry_with_gh_bin(DEFAULT_GH_BIN, owner, repo, issue_number, label)
+pub async fn add_label_with_retry(
+    owner: &str,
+    repo: &str,
+    issue_number: u32,
+    label: &str,
+) -> Result<()> {
+    add_label_with_retry_with_gh_bin(DEFAULT_GH_BIN, owner, repo, issue_number, label).await
 }
 
-pub fn add_label_with_retry_with_gh_bin(
+pub async fn add_label_with_retry_with_gh_bin(
     gh_bin: &str,
     owner: &str,
     repo: &str,
@@ -1417,6 +1473,7 @@ pub fn add_label_with_retry_with_gh_bin(
                 label,
             ])
             .output()
+            .await
             .map_err(|err| {
                 RalphError::Orchestration(format!(
                     "failed to run gh issue edit --add-label {label}: {err}"
@@ -1436,7 +1493,7 @@ pub fn add_label_with_retry_with_gh_bin(
                 delay.as_millis(),
                 stderr.trim()
             );
-            thread::sleep(delay);
+            tokio::time::sleep(delay).await;
             continue;
         }
 
@@ -1450,16 +1507,16 @@ pub fn add_label_with_retry_with_gh_bin(
 }
 
 /// Remove a label with retry-on-conflict/transient-failure behavior.
-pub fn remove_label_with_retry(
+pub async fn remove_label_with_retry(
     owner: &str,
     repo: &str,
     issue_number: u32,
     label: &str,
 ) -> Result<()> {
-    remove_label_with_retry_with_gh_bin(DEFAULT_GH_BIN, owner, repo, issue_number, label)
+    remove_label_with_retry_with_gh_bin(DEFAULT_GH_BIN, owner, repo, issue_number, label).await
 }
 
-pub fn remove_label_with_retry_with_gh_bin(
+pub async fn remove_label_with_retry_with_gh_bin(
     gh_bin: &str,
     owner: &str,
     repo: &str,
@@ -1479,6 +1536,7 @@ pub fn remove_label_with_retry_with_gh_bin(
                 label,
             ])
             .output()
+            .await
             .map_err(|err| {
                 RalphError::Orchestration(format!(
                     "failed to run gh issue edit --remove-label {label}: {err}"
@@ -1498,7 +1556,7 @@ pub fn remove_label_with_retry_with_gh_bin(
                 delay.as_millis(),
                 stderr.trim()
             );
-            thread::sleep(delay);
+            tokio::time::sleep(delay).await;
             continue;
         }
 
@@ -1512,11 +1570,11 @@ pub fn remove_label_with_retry_with_gh_bin(
 }
 
 /// Fetch the current lifecycle labels for an issue from GitHub.
-pub fn fetch_issue_labels(owner: &str, repo: &str, issue_number: u32) -> Result<Vec<String>> {
-    fetch_issue_labels_with_gh_bin(DEFAULT_GH_BIN, owner, repo, issue_number)
+pub async fn fetch_issue_labels(owner: &str, repo: &str, issue_number: u32) -> Result<Vec<String>> {
+    fetch_issue_labels_with_gh_bin(DEFAULT_GH_BIN, owner, repo, issue_number).await
 }
 
-pub fn fetch_issue_labels_with_gh_bin(
+pub async fn fetch_issue_labels_with_gh_bin(
     gh_bin: &str,
     owner: &str,
     repo: &str,
@@ -1534,6 +1592,7 @@ pub fn fetch_issue_labels_with_gh_bin(
             "labels",
         ])
         .output()
+        .await
         .map_err(|err| {
             RalphError::Orchestration(format!("failed to run gh issue view for labels: {err}"))
         })?;
@@ -1719,15 +1778,15 @@ pub struct IssueComment {
 /// Fetch all comments on an issue as structured data.
 ///
 /// Returns a list of [`IssueComment`] in chronological order.
-pub fn fetch_issue_comments(
+pub async fn fetch_issue_comments(
     owner: &str,
     repo: &str,
     issue_number: u32,
 ) -> Result<Vec<IssueComment>> {
-    fetch_issue_comments_with_gh_bin(DEFAULT_GH_BIN, owner, repo, issue_number)
+    fetch_issue_comments_with_gh_bin(DEFAULT_GH_BIN, owner, repo, issue_number).await
 }
 
-pub fn fetch_issue_comments_with_gh_bin(
+pub async fn fetch_issue_comments_with_gh_bin(
     gh_bin: &str,
     owner: &str,
     repo: &str,
@@ -1745,6 +1804,7 @@ pub fn fetch_issue_comments_with_gh_bin(
             "comments",
         ])
         .output()
+        .await
         .map_err(|err| {
             RalphError::Orchestration(format!(
                 "failed to fetch issue comments for {full_repo}#{issue_number}: {err}"
@@ -1805,14 +1865,15 @@ pub fn fetch_issue_comments_with_gh_bin(
 /// Resolve the GitHub login of the currently authenticated `gh` user.
 ///
 /// Uses `gh api user -q .login` and returns a non-empty login string.
-pub fn fetch_authenticated_login() -> Result<String> {
-    fetch_authenticated_login_with_gh_bin(DEFAULT_GH_BIN)
+pub async fn fetch_authenticated_login() -> Result<String> {
+    fetch_authenticated_login_with_gh_bin(DEFAULT_GH_BIN).await
 }
 
-pub fn fetch_authenticated_login_with_gh_bin(gh_bin: &str) -> Result<String> {
+pub async fn fetch_authenticated_login_with_gh_bin(gh_bin: &str) -> Result<String> {
     let output = Command::new(gh_bin)
         .args(["api", "user", "-q", ".login"])
         .output()
+        .await
         .map_err(|err| {
             RalphError::Orchestration(format!(
                 "failed to run gh api user for authenticated login: {err}"
@@ -1830,13 +1891,13 @@ pub fn fetch_authenticated_login_with_gh_bin(gh_bin: &str) -> Result<String> {
 }
 
 /// Check whether any comment on the issue contains the given marker string.
-pub fn find_comment_with_marker(
+pub async fn find_comment_with_marker(
     owner: &str,
     repo: &str,
     issue_number: u32,
     marker: &str,
 ) -> Result<Option<IssueComment>> {
-    let comments = fetch_issue_comments(owner, repo, issue_number)?;
+    let comments = fetch_issue_comments(owner, repo, issue_number).await?;
     Ok(comments.into_iter().find(|c| c.body.contains(marker)))
 }
 
@@ -1844,28 +1905,29 @@ pub fn find_comment_with_marker(
 /// marker already exists, skip posting and return the existing comment's ID.
 ///
 /// Returns the comment ID of the posted (or existing) comment.
-pub fn post_comment_with_marker(
+pub async fn post_comment_with_marker(
     owner: &str,
     repo: &str,
     issue_number: u32,
     marker: &str,
     body_text: &str,
 ) -> Result<Option<u64>> {
-    let meta = post_comment_with_marker_metadata(owner, repo, issue_number, marker, body_text)?;
+    let meta =
+        post_comment_with_marker_metadata(owner, repo, issue_number, marker, body_text).await?;
     Ok(meta.map(|c| c.id))
 }
 
 /// Post a comment on an issue with a marker prefix and return full structured
 /// metadata (id, created_at, etc.). If a comment with the same marker already
 /// exists, skip posting and return the existing comment's metadata.
-pub fn post_comment_with_marker_metadata(
+pub async fn post_comment_with_marker_metadata(
     owner: &str,
     repo: &str,
     issue_number: u32,
     marker: &str,
     body_text: &str,
 ) -> Result<Option<IssueComment>> {
-    if let Some(existing) = find_comment_with_marker(owner, repo, issue_number, marker)? {
+    if let Some(existing) = find_comment_with_marker(owner, repo, issue_number, marker).await? {
         return Ok(Some(existing));
     }
 
@@ -1882,6 +1944,7 @@ pub fn post_comment_with_marker_metadata(
             &full_body,
         ])
         .output()
+        .await
         .map_err(|err| {
             RalphError::Orchestration(format!(
                 "failed to post marker comment on {full_repo}#{issue_number}: {err}"
@@ -1896,7 +1959,7 @@ pub fn post_comment_with_marker_metadata(
     }
 
     // Fetch back to get the full metadata of the newly posted comment.
-    find_comment_with_marker(owner, repo, issue_number, marker)
+    find_comment_with_marker(owner, repo, issue_number, marker).await
 }
 
 /// Find a comment with the given marker string authored by the specified bot login.
@@ -1904,7 +1967,7 @@ pub fn post_comment_with_marker_metadata(
 /// Bot-scoped lookup: only matches comments where `author_login == bot_login`
 /// AND the body contains the marker string.  User-authored comments with the
 /// same marker text are ignored, preventing marker spoofing.
-pub fn find_bot_comment_with_marker(
+pub async fn find_bot_comment_with_marker(
     owner: &str,
     repo: &str,
     issue_number: u32,
@@ -1919,9 +1982,10 @@ pub fn find_bot_comment_with_marker(
         marker,
         bot_login,
     )
+    .await
 }
 
-pub fn find_bot_comment_with_marker_with_gh_bin(
+pub async fn find_bot_comment_with_marker_with_gh_bin(
     gh_bin: &str,
     owner: &str,
     repo: &str,
@@ -1929,7 +1993,7 @@ pub fn find_bot_comment_with_marker_with_gh_bin(
     marker: &str,
     bot_login: &str,
 ) -> Result<Option<IssueComment>> {
-    let comments = fetch_issue_comments_with_gh_bin(gh_bin, owner, repo, issue_number)?;
+    let comments = fetch_issue_comments_with_gh_bin(gh_bin, owner, repo, issue_number).await?;
     Ok(comments
         .into_iter()
         .find(|c| c.author_login == bot_login && c.body.contains(marker)))
@@ -1940,7 +2004,7 @@ pub fn find_bot_comment_with_marker_with_gh_bin(
 /// Only considers existing bot-authored comments when checking for duplicate
 /// markers.  User-authored spoof markers are ignored.  Returns `Some(id)` of
 /// the posted (or existing bot) comment.
-pub fn post_bot_comment_with_marker(
+pub async fn post_bot_comment_with_marker(
     owner: &str,
     repo: &str,
     issue_number: u32,
@@ -1957,9 +2021,10 @@ pub fn post_bot_comment_with_marker(
         body_text,
         bot_login,
     )
+    .await
 }
 
-pub fn post_bot_comment_with_marker_with_gh_bin(
+pub async fn post_bot_comment_with_marker_with_gh_bin(
     gh_bin: &str,
     owner: &str,
     repo: &str,
@@ -1976,7 +2041,8 @@ pub fn post_bot_comment_with_marker_with_gh_bin(
         marker,
         body_text,
         bot_login,
-    )?;
+    )
+    .await?;
     Ok(meta.map(|c| c.id))
 }
 
@@ -1985,7 +2051,7 @@ pub fn post_bot_comment_with_marker_with_gh_bin(
 ///
 /// Only considers existing bot-authored comments when checking for duplicate
 /// markers.  User-authored spoof markers are ignored.
-pub fn post_bot_comment_with_marker_metadata(
+pub async fn post_bot_comment_with_marker_metadata(
     owner: &str,
     repo: &str,
     issue_number: u32,
@@ -2002,9 +2068,10 @@ pub fn post_bot_comment_with_marker_metadata(
         body_text,
         bot_login,
     )
+    .await
 }
 
-pub fn post_bot_comment_with_marker_metadata_with_gh_bin(
+pub async fn post_bot_comment_with_marker_metadata_with_gh_bin(
     gh_bin: &str,
     owner: &str,
     repo: &str,
@@ -2020,7 +2087,9 @@ pub fn post_bot_comment_with_marker_metadata_with_gh_bin(
         issue_number,
         marker,
         bot_login,
-    )? {
+    )
+    .await?
+    {
         return Ok(Some(existing));
     }
 
@@ -2037,6 +2106,7 @@ pub fn post_bot_comment_with_marker_metadata_with_gh_bin(
             &full_body,
         ])
         .output()
+        .await
         .map_err(|err| {
             RalphError::Orchestration(format!(
                 "failed to post bot marker comment on {full_repo}#{issue_number}: {err}"
@@ -2052,14 +2122,15 @@ pub fn post_bot_comment_with_marker_metadata_with_gh_bin(
 
     // Fetch back to get the full metadata of the newly posted comment.
     find_bot_comment_with_marker_with_gh_bin(gh_bin, owner, repo, issue_number, marker, bot_login)
+        .await
 }
 
 /// Ensure PRD lifecycle labels exist in the repository (idempotent, best-effort).
-pub fn ensure_prd_labels_best_effort(owner: &str, repo: &str) {
-    ensure_prd_labels_best_effort_with_gh_bin(DEFAULT_GH_BIN, owner, repo);
+pub async fn ensure_prd_labels_best_effort(owner: &str, repo: &str) {
+    ensure_prd_labels_best_effort_with_gh_bin(DEFAULT_GH_BIN, owner, repo).await;
 }
 
-pub fn ensure_prd_labels_best_effort_with_gh_bin(gh_bin: &str, owner: &str, repo: &str) {
+pub async fn ensure_prd_labels_best_effort_with_gh_bin(gh_bin: &str, owner: &str, repo: &str) {
     use crate::daemon::interactive_prd::PRD_LABELS;
     let full_repo = format!("{owner}/{repo}");
 
@@ -2076,7 +2147,8 @@ pub fn ensure_prd_labels_best_effort_with_gh_bin(gh_bin: &str, owner: &str, repo
                 "--description",
                 description,
             ])
-            .output();
+            .output()
+            .await;
 
         match output {
             Ok(output) if output.status.success() => {}
@@ -2205,8 +2277,8 @@ mod tests {
         assert!(is_invalid_revision_error("fatal: bad revision 'foo'"));
     }
 
-    #[test]
-    fn has_diff_returns_false_for_single_commit_head_tilde_base() {
+    #[tokio::test]
+    async fn has_diff_returns_false_for_single_commit_head_tilde_base() {
         let temp = tempdir().expect("tempdir");
         let repo = temp.path();
 
@@ -2218,7 +2290,9 @@ mod tests {
         git(repo, &["add", "README.md"]);
         git(repo, &["commit", "-m", "initial"]);
 
-        let diff = has_diff(repo).expect("has_diff should not error for invalid base revision");
+        let diff = has_diff(repo)
+            .await
+            .expect("has_diff should not error for invalid base revision");
         assert!(
             !diff,
             "single-commit fallback HEAD~1 should be treated as no diff"
@@ -2485,12 +2559,13 @@ mod tests {
         assert!(!is_retryable_push_error(&unknown));
     }
 
-    #[test]
-    fn push_branch_with_retry_impl_retries_transient_then_succeeds() {
+    #[tokio::test]
+    async fn push_branch_with_retry_impl_retries_transient_then_succeeds() {
         let tmp = tempdir().expect("tempdir");
         let (git_bin, attempts_file) = write_mock_git_binary(tmp.path(), "transient_then_success");
 
-        let result = push_branch_with_retry_impl(&git_bin, tmp.path(), "feature/test", &[0, 0, 0]);
+        let result =
+            push_branch_with_retry_impl(&git_bin, tmp.path(), "feature/test", &[0, 0, 0]).await;
         assert!(result.is_ok(), "expected retry flow to recover: {result:?}");
         assert_eq!(
             read_attempts(&attempts_file),
@@ -2499,12 +2574,13 @@ mod tests {
         );
     }
 
-    #[test]
-    fn push_branch_with_retry_impl_does_not_retry_permanent_failure() {
+    #[tokio::test]
+    async fn push_branch_with_retry_impl_does_not_retry_permanent_failure() {
         let tmp = tempdir().expect("tempdir");
         let (git_bin, attempts_file) = write_mock_git_binary(tmp.path(), "permanent_failure");
 
-        let result = push_branch_with_retry_impl(&git_bin, tmp.path(), "feature/test", &[0, 0, 0]);
+        let result =
+            push_branch_with_retry_impl(&git_bin, tmp.path(), "feature/test", &[0, 0, 0]).await;
         assert!(result.is_err(), "expected permanent failure");
         assert_eq!(
             read_attempts(&attempts_file),
@@ -2513,12 +2589,13 @@ mod tests {
         );
     }
 
-    #[test]
-    fn push_branch_with_retry_impl_exhausts_retries_for_transient_failure() {
+    #[tokio::test]
+    async fn push_branch_with_retry_impl_exhausts_retries_for_transient_failure() {
         let tmp = tempdir().expect("tempdir");
         let (git_bin, attempts_file) = write_mock_git_binary(tmp.path(), "transient_exhaustion");
 
-        let result = push_branch_with_retry_impl(&git_bin, tmp.path(), "feature/test", &[0, 0, 0]);
+        let result =
+            push_branch_with_retry_impl(&git_bin, tmp.path(), "feature/test", &[0, 0, 0]).await;
         assert!(result.is_err(), "expected transient retry exhaustion");
         assert_eq!(
             read_attempts(&attempts_file),
@@ -2527,12 +2604,13 @@ mod tests {
         );
     }
 
-    #[test]
-    fn push_branch_with_retry_impl_classifies_on_stderr_not_branch_name() {
+    #[tokio::test]
+    async fn push_branch_with_retry_impl_classifies_on_stderr_not_branch_name() {
         let tmp = tempdir().expect("tempdir");
         let (git_bin, attempts_file) = write_mock_git_binary(tmp.path(), "transient_then_success");
 
-        let result = push_branch_with_retry_impl(&git_bin, tmp.path(), "fix/issue-403", &[0, 0, 0]);
+        let result =
+            push_branch_with_retry_impl(&git_bin, tmp.path(), "fix/issue-403", &[0, 0, 0]).await;
         assert!(
             result.is_ok(),
             "transient stderr should retry regardless of branch name collision: {result:?}"
@@ -2546,7 +2624,8 @@ mod tests {
         let tmp = tempdir().expect("tempdir");
         let (git_bin, attempts_file) = write_mock_git_binary(tmp.path(), "permanent_failure");
         let result =
-            push_branch_with_retry_impl(&git_bin, tmp.path(), "feature/500-errors", &[0, 0, 0]);
+            push_branch_with_retry_impl(&git_bin, tmp.path(), "feature/500-errors", &[0, 0, 0])
+                .await;
         assert!(
             result.is_err(),
             "permanent stderr should fail even when branch name contains 500: {result:?}"
@@ -2558,12 +2637,13 @@ mod tests {
         );
     }
 
-    #[test]
-    fn push_branch_with_retry_impl_does_not_retry_unknown_failure() {
+    #[tokio::test]
+    async fn push_branch_with_retry_impl_does_not_retry_unknown_failure() {
         let tmp = tempdir().expect("tempdir");
         let (git_bin, attempts_file) = write_mock_git_binary(tmp.path(), "unknown_failure");
 
-        let result = push_branch_with_retry_impl(&git_bin, tmp.path(), "feature/test", &[0, 0, 0]);
+        let result =
+            push_branch_with_retry_impl(&git_bin, tmp.path(), "feature/test", &[0, 0, 0]).await;
         assert!(result.is_err(), "expected unknown failure");
         assert_eq!(
             read_attempts(&attempts_file),

--- a/src/daemon/interactive_prd.rs
+++ b/src/daemon/interactive_prd.rs
@@ -15,6 +15,24 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use crate::backend::{claude, codex, parse_backend_spec, Backend, CliBackend};
+
+/// Block on an async future from sync code.
+///
+/// When called from within a tokio runtime (e.g. via `spawn_blocking`), uses
+/// `Handle::current().block_on()`. When no runtime is active (e.g. in sync
+/// tests), creates a temporary single-threaded runtime.
+fn block_on_async<F: std::future::Future>(f: F) -> F::Output {
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) => handle.block_on(f),
+        Err(_) => {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("failed to create temporary tokio runtime");
+            rt.block_on(f)
+        }
+    }
+}
 use crate::config::GlobalConfig;
 use crate::daemon::github::{self, GhIssue};
 use crate::error::RalphError;
@@ -618,13 +636,13 @@ fn ensure_waiting_feedback_label(config: &PrdPollConfig, issue_number: u32, labe
         return;
     }
 
-    let _ = github::add_label_with_retry_with_gh_bin(
+    let _ = block_on_async(github::add_label_with_retry_with_gh_bin(
         &config.gh_bin,
         &config.owner,
         &config.repo,
         issue_number,
         WAITING_FEEDBACK_LABEL,
-    );
+    ));
 }
 
 // ---------------------------------------------------------------------------
@@ -723,16 +741,20 @@ pub const REQUIRED_SPEC_SECTION_COUNT: usize = 6;
 pub fn poll_and_advance_prd(config: &PrdPollConfig) -> Result<()> {
     // Phase 1: sequential polls
     let labels = vec!["ralph:prd".to_owned()];
-    let (issues, _overflow) =
-        github::poll_issues_with_gh_bin(&config.gh_bin, &config.owner, &config.repo, &labels)?;
+    let (issues, _overflow) = block_on_async(github::poll_issues_with_gh_bin(
+        &config.gh_bin,
+        &config.owner,
+        &config.repo,
+        &labels,
+    ))?;
 
     let active_labels = vec!["ralph:prd-active".to_owned()];
-    let (active_issues, _) = github::poll_issues_with_gh_bin(
+    let (active_issues, _) = block_on_async(github::poll_issues_with_gh_bin(
         &config.gh_bin,
         &config.owner,
         &config.repo,
         &active_labels,
-    )?;
+    ))?;
 
     // Phase 2: deduplicate issues across both passes
     let mut seen = std::collections::HashSet::new();
@@ -1014,13 +1036,13 @@ fn do_pending_to_awaiting(
     let has_active = issue.labels.iter().any(|l| l == "ralph:prd-active");
 
     if !has_active {
-        github::add_label_with_retry_with_gh_bin(
+        block_on_async(github::add_label_with_retry_with_gh_bin(
             &config.gh_bin,
             owner,
             repo,
             issue_number,
             "ralph:prd-active",
-        )
+        ))
         .map_err(|err| {
             RalphError::InteractivePrdFailed(format!(
                 "failed to add ralph:prd-active for {owner}/{repo}#{issue_number}: {err}"
@@ -1028,24 +1050,24 @@ fn do_pending_to_awaiting(
         })?;
     }
     if has_prd {
-        let _ = github::remove_label_with_retry_with_gh_bin(
+        let _ = block_on_async(github::remove_label_with_retry_with_gh_bin(
             &config.gh_bin,
             owner,
             repo,
             issue_number,
             "ralph:prd",
-        );
+        ));
     }
 
     // 2. Remove ralph:ready if present (prevent dual workflow ownership)
     if issue.labels.iter().any(|l| l == "ralph:ready") {
-        let _ = github::remove_label_with_retry_with_gh_bin(
+        let _ = block_on_async(github::remove_label_with_retry_with_gh_bin(
             &config.gh_bin,
             owner,
             repo,
             issue_number,
             "ralph:ready",
-        );
+        ));
     }
 
     // 3. Check if questions marker already exists (idempotent restart/retry).
@@ -1054,14 +1076,14 @@ fn do_pending_to_awaiting(
     let next_revision = state.question_revision + 1;
     let marker = prd_marker(issue_number, "questions", next_revision);
 
-    let existing_marker_comment = github::find_bot_comment_with_marker_with_gh_bin(
+    let existing_marker_comment = block_on_async(github::find_bot_comment_with_marker_with_gh_bin(
         &config.gh_bin,
         owner,
         repo,
         issue_number,
         &marker,
         bot_login,
-    )
+    ))
     .map_err(|err| {
         RalphError::InteractivePrdFailed(format!(
             "failed to check existing marker for {owner}/{repo}#{issue_number}: {err}"
@@ -1095,20 +1117,21 @@ fn do_pending_to_awaiting(
         // timestamp rather than local wall clock. This ensures answer-gating
         // compares against the real comment time consistently.
         // Uses bot-scoped posting so user-authored spoof markers are ignored.
-        let posted_meta = github::post_bot_comment_with_marker_metadata_with_gh_bin(
-            &config.gh_bin,
-            owner,
-            repo,
-            issue_number,
-            &marker,
-            &comment_body,
-            bot_login,
-        )
-        .map_err(|err| {
-            RalphError::InteractivePrdFailed(format!(
-                "failed to post questions comment for {owner}/{repo}#{issue_number}: {err}"
+        let posted_meta =
+            block_on_async(github::post_bot_comment_with_marker_metadata_with_gh_bin(
+                &config.gh_bin,
+                owner,
+                repo,
+                issue_number,
+                &marker,
+                &comment_body,
+                bot_login,
             ))
-        })?;
+            .map_err(|err| {
+                RalphError::InteractivePrdFailed(format!(
+                    "failed to post questions comment for {owner}/{repo}#{issue_number}: {err}"
+                ))
+            })?;
 
         match posted_meta {
             Some(meta) => (Some(meta.id), meta.created_at),
@@ -1137,7 +1160,10 @@ fn get_or_fetch_bot_login(
         return Ok(login);
     }
 
-    let login = github::fetch_authenticated_login_with_gh_bin(&config.gh_bin).map_err(|err| {
+    let login = block_on_async(github::fetch_authenticated_login_with_gh_bin(
+        &config.gh_bin,
+    ))
+    .map_err(|err| {
         RalphError::InteractivePrdFailed(format!("failed to resolve authenticated gh login: {err}"))
     })?;
     *bot_login_cache = Some(login.clone());
@@ -1185,13 +1211,17 @@ fn do_awaiting_answers_to_awaiting_feedback(
         ))
     })?;
 
-    let comments =
-        github::fetch_issue_comments_with_gh_bin(&config.gh_bin, owner, repo, issue_number)
-            .map_err(|err| {
-                RalphError::InteractivePrdFailed(format!(
-                    "failed to fetch comments for {owner}/{repo}#{issue_number}: {err}"
-                ))
-            })?;
+    let comments = block_on_async(github::fetch_issue_comments_with_gh_bin(
+        &config.gh_bin,
+        owner,
+        repo,
+        issue_number,
+    ))
+    .map_err(|err| {
+        RalphError::InteractivePrdFailed(format!(
+            "failed to fetch comments for {owner}/{repo}#{issue_number}: {err}"
+        ))
+    })?;
 
     let Some(answer_comment) = find_first_answer_comment(
         &comments,
@@ -1241,7 +1271,7 @@ fn do_awaiting_answers_to_awaiting_feedback(
     let next_revision = state.draft_revision + 1;
     let marker = prd_marker(issue_number, "draft", next_revision);
     let draft_comment_body = format_draft_comment(next_revision, &draft_spec);
-    let comment_id = github::post_bot_comment_with_marker_with_gh_bin(
+    let comment_id = block_on_async(github::post_bot_comment_with_marker_with_gh_bin(
         &config.gh_bin,
         owner,
         repo,
@@ -1249,7 +1279,7 @@ fn do_awaiting_answers_to_awaiting_feedback(
         &marker,
         &draft_comment_body,
         bot_login,
-    )
+    ))
     .map_err(|err| {
         RalphError::InteractivePrdFailed(format!(
             "failed to post draft comment for {owner}/{repo}#{issue_number}: {err}"
@@ -1321,20 +1351,29 @@ fn do_awaiting_feedback(
     let repo = &config.repo;
 
     // Fetch current labels and comments
-    let labels = github::fetch_issue_labels_with_gh_bin(&config.gh_bin, owner, repo, issue_number)
-        .map_err(|err| {
-            RalphError::InteractivePrdFailed(format!(
-                "failed to fetch labels for {owner}/{repo}#{issue_number}: {err}"
-            ))
-        })?;
+    let labels = block_on_async(github::fetch_issue_labels_with_gh_bin(
+        &config.gh_bin,
+        owner,
+        repo,
+        issue_number,
+    ))
+    .map_err(|err| {
+        RalphError::InteractivePrdFailed(format!(
+            "failed to fetch labels for {owner}/{repo}#{issue_number}: {err}"
+        ))
+    })?;
 
-    let comments =
-        github::fetch_issue_comments_with_gh_bin(&config.gh_bin, owner, repo, issue_number)
-            .map_err(|err| {
-                RalphError::InteractivePrdFailed(format!(
-                    "failed to fetch comments for {owner}/{repo}#{issue_number}: {err}"
-                ))
-            })?;
+    let comments = block_on_async(github::fetch_issue_comments_with_gh_bin(
+        &config.gh_bin,
+        owner,
+        repo,
+        issue_number,
+    ))
+    .map_err(|err| {
+        RalphError::InteractivePrdFailed(format!(
+            "failed to fetch comments for {owner}/{repo}#{issue_number}: {err}"
+        ))
+    })?;
 
     // Check approval by label
     if labels.iter().any(|l| l == "ralph:prd-approved") {
@@ -1401,7 +1440,7 @@ fn do_awaiting_feedback(
     let next_revision = state.draft_revision + 1;
     let marker = prd_marker(issue_number, "draft", next_revision);
     let draft_comment_body = format_draft_comment(next_revision, &revised_spec);
-    let comment_id = github::post_bot_comment_with_marker_with_gh_bin(
+    let comment_id = block_on_async(github::post_bot_comment_with_marker_with_gh_bin(
         &config.gh_bin,
         owner,
         repo,
@@ -1409,7 +1448,7 @@ fn do_awaiting_feedback(
         &marker,
         &draft_comment_body,
         bot_login,
-    )
+    ))
     .map_err(|err| {
         RalphError::InteractivePrdFailed(format!(
             "failed to post revision comment for {owner}/{repo}#{issue_number}: {err}"
@@ -1452,7 +1491,7 @@ fn do_approval_transition(
          *The interactive PRD workflow is now complete.*",
         state.draft_revision
     );
-    github::post_bot_comment_with_marker_with_gh_bin(
+    block_on_async(github::post_bot_comment_with_marker_with_gh_bin(
         &config.gh_bin,
         owner,
         repo,
@@ -1460,7 +1499,7 @@ fn do_approval_transition(
         &marker,
         &approval_body,
         bot_login,
-    )
+    ))
     .map_err(|err| {
         RalphError::InteractivePrdFailed(format!(
             "failed to post approval comment for {owner}/{repo}#{issue_number}: {err}"
@@ -1469,13 +1508,13 @@ fn do_approval_transition(
 
     // Add ralph:prd-done BEFORE removing ralph:prd-active. On partial failure
     // the issue retains ralph:prd-active (poll-visible) and gains ralph:prd-done.
-    github::add_label_with_retry_with_gh_bin(
+    block_on_async(github::add_label_with_retry_with_gh_bin(
         &config.gh_bin,
         owner,
         repo,
         issue_number,
         "ralph:prd-done",
-    )
+    ))
     .map_err(|err| {
         RalphError::InteractivePrdFailed(format!(
             "failed to add ralph:prd-done for {owner}/{repo}#{issue_number}: {err}"
@@ -1504,21 +1543,21 @@ fn do_approval_transition(
     // Save succeeded — now safe to remove terminal cleanup labels.
     // Attempt both removals independently so one failure never suppresses
     // the other cleanup operation.
-    let active_remove_err = github::remove_label_with_retry_with_gh_bin(
+    let active_remove_err = block_on_async(github::remove_label_with_retry_with_gh_bin(
         &config.gh_bin,
         owner,
         repo,
         issue_number,
         "ralph:prd-active",
-    )
+    ))
     .err();
-    let waiting_remove_err = github::remove_label_with_retry_with_gh_bin(
+    let waiting_remove_err = block_on_async(github::remove_label_with_retry_with_gh_bin(
         &config.gh_bin,
         owner,
         repo,
         issue_number,
         WAITING_FEEDBACK_LABEL,
-    )
+    ))
     .err();
 
     if let Some(err) = &active_remove_err {
@@ -2099,7 +2138,7 @@ fn transition_to_failed(
     );
 
     if let Some(login) = bot_login {
-        let _ = github::post_bot_comment_with_marker_with_gh_bin(
+        let _ = block_on_async(github::post_bot_comment_with_marker_with_gh_bin(
             &config.gh_bin,
             owner,
             repo,
@@ -2107,28 +2146,28 @@ fn transition_to_failed(
             &marker,
             &error_body,
             login,
-        );
+        ));
     } else {
         // No bot identity — post without idempotency check rather than using
         // body-only lookup (which a user spoof could suppress).
         let full_body = format!("{marker}\n{error_body}");
-        let _ = github::post_raw_issue_comment_with_gh_bin(
+        let _ = block_on_async(github::post_raw_issue_comment_with_gh_bin(
             &config.gh_bin,
             owner,
             repo,
             issue_number,
             &full_body,
-        );
+        ));
     }
 
     // Add ralph:prd-failed BEFORE removing ralph:prd-active (boundary-safe ordering).
-    let _ = github::add_label_with_retry_with_gh_bin(
+    let _ = block_on_async(github::add_label_with_retry_with_gh_bin(
         &config.gh_bin,
         owner,
         repo,
         issue_number,
         "ralph:prd-failed",
-    );
+    ));
 
     // Set terminal state and persist BEFORE removing the poll-visible labels.
     let prev_state = state.state.clone();
@@ -2152,27 +2191,27 @@ fn transition_to_failed(
     }
 
     // Save succeeded — now safe to remove poll-visible labels
-    let _ = github::remove_label_with_retry_with_gh_bin(
+    let _ = block_on_async(github::remove_label_with_retry_with_gh_bin(
         &config.gh_bin,
         owner,
         repo,
         issue_number,
         "ralph:prd-active",
-    );
-    let _ = github::remove_label_with_retry_with_gh_bin(
+    ));
+    let _ = block_on_async(github::remove_label_with_retry_with_gh_bin(
         &config.gh_bin,
         owner,
         repo,
         issue_number,
         "ralph:prd",
-    );
-    let _ = github::remove_label_with_retry_with_gh_bin(
+    ));
+    let _ = block_on_async(github::remove_label_with_retry_with_gh_bin(
         &config.gh_bin,
         owner,
         repo,
         issue_number,
         WAITING_FEEDBACK_LABEL,
-    );
+    ));
 
     Ok(())
 }
@@ -2296,9 +2335,14 @@ pub fn extract_approved_spec(
     repo: &str,
     issue_number: u32,
 ) -> Option<String> {
-    let bot_login = github::fetch_authenticated_login_with_gh_bin(gh_bin).ok()?;
-    let comments =
-        github::fetch_issue_comments_with_gh_bin(gh_bin, owner, repo, issue_number).ok()?;
+    let bot_login = block_on_async(github::fetch_authenticated_login_with_gh_bin(gh_bin)).ok()?;
+    let comments = block_on_async(github::fetch_issue_comments_with_gh_bin(
+        gh_bin,
+        owner,
+        repo,
+        issue_number,
+    ))
+    .ok()?;
     parse_approved_spec_from_comments(&comments, &bot_login, issue_number)
 }
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -51,14 +51,14 @@ pub fn format_task_id(owner: &str, repo: &str, issue_number: u32) -> String {
 ///
 /// The caller is responsible for removing the child from the in-memory map.
 /// This function only performs process termination and label updates.
-pub fn abort_task_by_labels(
+pub async fn abort_task_by_labels(
     owner: &str,
     repo: &str,
     issue_number: u32,
     child_pid: Option<u32>,
     child_pgid: Option<u32>,
 ) -> Result<()> {
-    terminate_process_group_if_present(child_pid, child_pgid);
+    terminate_process_group_if_present(child_pid, child_pgid).await;
 
     // Swap label: ralph:in-progress -> ralph:failed
     github::swap_lifecycle_label(
@@ -68,6 +68,7 @@ pub fn abort_task_by_labels(
         "ralph:in-progress",
         "ralph:failed",
     )
+    .await
     .map_err(|err| {
         RalphError::Orchestration(format!(
             "failed to update labels for abort of {owner}/{repo}#{issue_number}: {err}"
@@ -77,15 +78,15 @@ pub fn abort_task_by_labels(
     Ok(())
 }
 
-fn terminate_process_group_if_present(child_pid: Option<u32>, child_pgid: Option<u32>) {
+async fn terminate_process_group_if_present(child_pid: Option<u32>, child_pgid: Option<u32>) {
     // Prefer killing by process group; fall back to single PID.
     if let Some(pgid) = child_pgid.filter(|v| *v > 0) {
-        daemon_process::terminate_process_group_blocking(pgid, Duration::from_secs(10));
+        daemon_process::terminate_process_group(pgid, Duration::from_secs(10)).await;
         return;
     }
     if let Some(pid) = child_pid.filter(|v| *v > 0) {
         // No PGID available — treat the single PID as a one-member "group".
-        daemon_process::terminate_process_group_blocking(pid, Duration::from_secs(10));
+        daemon_process::terminate_process_group(pid, Duration::from_secs(10)).await;
     }
 }
 

--- a/src/daemon/process.rs
+++ b/src/daemon/process.rs
@@ -568,18 +568,6 @@ pub async fn terminate_process_group(pgid: u32, timeout: Duration) {
     let _ = killpg(pgid, Signal::SIGKILL);
 }
 
-pub fn terminate_process_group_blocking(pgid: u32, timeout: Duration) {
-    match tokio::runtime::Builder::new_current_thread()
-        .enable_time()
-        .build()
-    {
-        Ok(runtime) => runtime.block_on(terminate_process_group(pgid, timeout)),
-        Err(err) => {
-            eprintln!("warning: failed to initialize tokio runtime for abort path: {err}");
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use chrono::DateTime;
@@ -595,7 +583,7 @@ mod tests {
         has_content_for_separator,
     };
     #[cfg(unix)]
-    use super::{pid_exists, terminate_process_group_blocking};
+    use super::{pid_exists, terminate_process_group};
 
     #[test]
     fn spawn_command_uses_long_idea_flag() {
@@ -837,22 +825,22 @@ mod tests {
     }
 
     #[cfg(unix)]
-    #[test]
-    fn test_terminate_process_group_noop_for_low_pgid() {
-        terminate_process_group_blocking(0, Duration::from_millis(50));
-        terminate_process_group_blocking(1, Duration::from_millis(50));
+    #[tokio::test]
+    async fn test_terminate_process_group_noop_for_low_pgid() {
+        terminate_process_group(0, Duration::from_millis(50)).await;
+        terminate_process_group(1, Duration::from_millis(50)).await;
     }
 
     #[cfg(unix)]
-    #[test]
-    fn test_terminate_process_group_dead_pgid() {
+    #[tokio::test]
+    async fn test_terminate_process_group_dead_pgid() {
         let mut child = std::process::Command::new("sleep")
             .arg("30")
             .spawn()
             .expect("spawn child");
         let non_group_id = child.id();
 
-        terminate_process_group_blocking(non_group_id, Duration::from_millis(50));
+        terminate_process_group(non_group_id, Duration::from_millis(50)).await;
         assert!(
             child.try_wait().expect("poll child").is_none(),
             "child should still be running"
@@ -863,8 +851,8 @@ mod tests {
     }
 
     #[cfg(unix)]
-    #[test]
-    fn test_terminate_spawned_process_group() {
+    #[tokio::test]
+    async fn test_terminate_spawned_process_group() {
         use std::os::unix::process::{CommandExt, ExitStatusExt};
 
         let mut child = std::process::Command::new("sleep")
@@ -874,7 +862,7 @@ mod tests {
             .expect("spawn process-group leader");
         let pgid = child.id();
 
-        terminate_process_group_blocking(pgid, Duration::from_secs(2));
+        terminate_process_group(pgid, Duration::from_secs(2)).await;
 
         let deadline = Instant::now() + Duration::from_secs(3);
         let status = loop {

--- a/src/daemon/runtime.rs
+++ b/src/daemon/runtime.rs
@@ -165,13 +165,7 @@ impl ArtifactCommentClient for GitHubArtifactCommentClient {
         issue_number: u32,
         marker: &str,
     ) -> Result<bool> {
-        let owner = owner.to_owned();
-        let repo = repo.to_owned();
-        let marker = marker.to_owned();
-        spawn_blocking_op(move || {
-            github::comment_marker_exists(&owner, &repo, issue_number, &marker)
-        })
-        .await
+        github::comment_marker_exists(owner, repo, issue_number, marker).await
     }
 
     async fn post_idempotent_comment(
@@ -183,22 +177,7 @@ impl ArtifactCommentClient for GitHubArtifactCommentClient {
         phase: &str,
         body_text: &str,
     ) -> Result<()> {
-        let owner = owner.to_owned();
-        let repo = repo.to_owned();
-        let task_id = task_id.to_owned();
-        let phase = phase.to_owned();
-        let body_text = body_text.to_owned();
-        spawn_blocking_op(move || {
-            github::post_idempotent_comment(
-                &owner,
-                &repo,
-                issue_number,
-                &task_id,
-                &phase,
-                &body_text,
-            )
-        })
-        .await
+        github::post_idempotent_comment(owner, repo, issue_number, task_id, phase, body_text).await
     }
 }
 
@@ -258,9 +237,7 @@ async fn draft_pr_watcher_with_sleep<S, SFut>(
     loop {
         // Check if branch has commits ahead of base
         let has_ahead = {
-            let wt = worktree_path.clone();
-            let base = base_branch.clone();
-            match spawn_blocking_op(move || github::has_commits_ahead_of_base(&wt, &base)).await {
+            match github::has_commits_ahead_of_base(&worktree_path, &base_branch).await {
                 Ok(v) => {
                     consecutive_failures = 0;
                     v
@@ -286,9 +263,7 @@ async fn draft_pr_watcher_with_sleep<S, SFut>(
         if has_ahead && !pr_created {
             // Step 1: push unconditionally before creating draft PR
             let push_ok = {
-                let wt = worktree_path.clone();
-                let br = branch.clone();
-                match spawn_blocking_op(move || github::push_branch_with_retry(&wt, &br)).await {
+                match github::push_branch_with_retry(&worktree_path, &branch).await {
                     Ok(()) => {
                         eprintln!("draft-pr-watcher: pushed branch {branch} for {task_id}");
                         true
@@ -304,17 +279,10 @@ async fn draft_pr_watcher_with_sleep<S, SFut>(
 
             // Step 2: create draft PR
             if push_ok {
-                let owner_c = owner.clone();
-                let repo_c = repo.clone();
-                let br = branch.clone();
-                let tid = task_id.clone();
-                let title = format!("[Draft] {tid}");
-                let body = format!("Automated draft PR for task `{tid}` (issue #{issue_number}).");
-                match spawn_blocking_op(move || {
-                    github::create_pr(&owner_c, &repo_c, &br, &title, &body, true)
-                })
-                .await
-                {
+                let title = format!("[Draft] {task_id}");
+                let body =
+                    format!("Automated draft PR for task `{task_id}` (issue #{issue_number}).");
+                match github::create_pr(&owner, &repo, &branch, &title, &body, true).await {
                     Ok(url) => {
                         eprintln!("draft-pr-watcher: created draft PR for {task_id}: {url}");
                         pr_created = true;
@@ -330,13 +298,8 @@ async fn draft_pr_watcher_with_sleep<S, SFut>(
                             "draft-pr-watcher: failed to create draft PR for {task_id}: {err}"
                         );
                         // Re-check: another process may have created the PR concurrently.
-                        let owner_retry = owner.clone();
-                        let repo_retry = repo.clone();
-                        let br_retry = branch.clone();
-                        if let Ok(Some(url)) = spawn_blocking_op(move || {
-                            github::find_existing_pr(&owner_retry, &repo_retry, &br_retry)
-                        })
-                        .await
+                        if let Ok(Some(url)) =
+                            github::find_existing_pr(&owner, &repo, &branch).await
                         {
                             eprintln!("draft-pr-watcher: found existing PR for {task_id}: {url}");
                             pr_created = true;
@@ -695,9 +658,9 @@ fn read_nonempty_artifact(path: &Path) -> Option<String> {
 
 /// Re-trigger a failed task by claiming its GitHub issue via label swap:
 /// `ralph:failed` -> `ralph:ready`.
-pub fn retrigger_failed_task(owner: &str, repo: &str, issue_number: u32) -> Result<()> {
+pub async fn retrigger_failed_task(owner: &str, repo: &str, issue_number: u32) -> Result<()> {
     // Verify current label state from GitHub
-    let labels = github::fetch_issue_labels(owner, repo, issue_number)?;
+    let labels = github::fetch_issue_labels(owner, repo, issue_number).await?;
     let lifecycle = github::classify_lifecycle_labels(&labels);
 
     if !lifecycle.iter().any(|l| l == "ralph:failed") {
@@ -708,7 +671,7 @@ pub fn retrigger_failed_task(owner: &str, repo: &str, issue_number: u32) -> Resu
     }
 
     // Swap failed -> ready so the daemon picks it up on next poll
-    github::swap_lifecycle_label(owner, repo, issue_number, "ralph:failed", "ralph:ready")?;
+    github::swap_lifecycle_label(owner, repo, issue_number, "ralph:failed", "ralph:ready").await?;
 
     eprintln!(
         "retrigger: event=success repo={owner}/{repo} issue_number={issue_number} transition=failed_to_ready"
@@ -824,12 +787,7 @@ pub async fn run(config: &DaemonRuntimeConfig) -> Result<()> {
 
     // Phase 1: Startup reconciliation — reset all `ralph:in-progress` to `ralph:ready`.
     // Always queries `ralph:in-progress` regardless of configured poll labels.
-    {
-        let owner = config.owner.clone();
-        let repo = config.repo.clone();
-        let verbose = config.verbose;
-        spawn_blocking_op(move || reconcile_in_progress_labels(&owner, &repo, verbose)).await?;
-    }
+    reconcile_in_progress_labels(&config.owner, &config.repo, config.verbose).await?;
 
     // Phase 2: PRD background task lifecycle
     let prd_cancel = CancellationToken::new();
@@ -1002,10 +960,10 @@ async fn run_prd_phase(
 ///
 /// Always queries `ralph:in-progress` directly rather than using configured
 /// poll labels, ensuring stale issues are caught regardless of label config.
-fn reconcile_in_progress_labels(owner: &str, repo: &str, verbose: bool) -> Result<()> {
+async fn reconcile_in_progress_labels(owner: &str, repo: &str, verbose: bool) -> Result<()> {
     // Always query ralph:in-progress explicitly to catch all stale issues
     let reconcile_labels = vec!["ralph:in-progress".to_owned()];
-    let (issues, _overflow) = github::poll_issues(owner, repo, &reconcile_labels)?;
+    let (issues, _overflow) = github::poll_issues(owner, repo, &reconcile_labels).await?;
 
     let mut reconciled = 0u32;
     for issue in &issues {
@@ -1017,7 +975,9 @@ fn reconcile_in_progress_labels(owner: &str, repo: &str, verbose: bool) -> Resul
                 issue.number,
                 "ralph:in-progress",
                 "ralph:ready",
-            ) {
+            )
+            .await
+            {
                 eprintln!(
                     "reconcile: failed to reset issue #{} from in-progress to ready: {err}",
                     issue.number
@@ -1082,12 +1042,8 @@ async fn poll_and_claim(
     slots: u32,
     repo_root_lock: &Arc<Semaphore>,
 ) -> Result<()> {
-    let (issues, overflow) = {
-        let owner = config.owner.clone();
-        let repo = config.repo.clone();
-        let labels = config.labels.clone();
-        spawn_blocking_op(move || github::poll_issues(&owner, &repo, &labels)).await?
-    };
+    let (issues, overflow) =
+        github::poll_issues(&config.owner, &config.repo, &config.labels).await?;
 
     if overflow {
         eprintln!("warning: gh issue list returned exactly 100 issues; results may be truncated");
@@ -1105,18 +1061,12 @@ async fn poll_and_claim(
 
         // Multi-lifecycle-label normalization
         if lifecycle.len() > 1 {
-            let owner = config.owner.clone();
-            let repo = config.repo.clone();
-            let issue_number = issue.number;
-            let lifecycle_clone = lifecycle.clone();
-            match spawn_blocking_op(move || {
-                github::normalize_multi_lifecycle_labels(
-                    &owner,
-                    &repo,
-                    issue_number,
-                    &lifecycle_clone,
-                )
-            })
+            match github::normalize_multi_lifecycle_labels(
+                &config.owner,
+                &config.repo,
+                issue.number,
+                &lifecycle,
+            )
             .await
             {
                 Ok(true) => {
@@ -1159,24 +1109,17 @@ async fn poll_and_claim(
         }
 
         // Claim: ready -> in-progress
+        if let Err(err) = github::swap_lifecycle_label(
+            &config.owner,
+            &config.repo,
+            issue.number,
+            "ralph:ready",
+            "ralph:in-progress",
+        )
+        .await
         {
-            let owner = config.owner.clone();
-            let repo = config.repo.clone();
-            let issue_number = issue.number;
-            if let Err(err) = spawn_blocking_op(move || {
-                github::swap_lifecycle_label(
-                    &owner,
-                    &repo,
-                    issue_number,
-                    "ralph:ready",
-                    "ralph:in-progress",
-                )
-            })
-            .await
-            {
-                eprintln!("warning: failed to claim issue #{}: {err}", issue.number);
-                continue;
-            }
+            eprintln!("warning: failed to claim issue #{}: {err}", issue.number);
+            continue;
         }
 
         // Dispatch input selection: for prd-done issues, attempt to recover
@@ -1296,17 +1239,13 @@ async fn poll_and_claim(
             } => {
                 eprintln!("warning: failed to dispatch issue #{issue_number}: {detail}");
                 // Per-issue rollback: swap ralph:in-progress -> ralph:failed
-                let owner = config.owner.clone();
-                let repo = config.repo.clone();
-                if let Err(rollback_err) = spawn_blocking_op(move || {
-                    github::swap_lifecycle_label(
-                        &owner,
-                        &repo,
-                        issue_number,
-                        "ralph:in-progress",
-                        "ralph:failed",
-                    )
-                })
+                if let Err(rollback_err) = github::swap_lifecycle_label(
+                    &config.owner,
+                    &config.repo,
+                    issue_number,
+                    "ralph:in-progress",
+                    "ralph:failed",
+                )
                 .await
                 {
                     eprintln!(
@@ -1320,17 +1259,13 @@ async fn poll_and_claim(
             } => {
                 eprintln!("warning: dispatch worker panicked for issue #{issue_number}: {detail}");
                 // Per-issue rollback: same path as Err — swap ralph:in-progress -> ralph:failed
-                let owner = config.owner.clone();
-                let repo = config.repo.clone();
-                if let Err(rollback_err) = spawn_blocking_op(move || {
-                    github::swap_lifecycle_label(
-                        &owner,
-                        &repo,
-                        issue_number,
-                        "ralph:in-progress",
-                        "ralph:failed",
-                    )
-                })
+                if let Err(rollback_err) = github::swap_lifecycle_label(
+                    &config.owner,
+                    &config.repo,
+                    issue_number,
+                    "ralph:in-progress",
+                    "ralph:failed",
+                )
                 .await
                 {
                     eprintln!(
@@ -1523,13 +1458,8 @@ async fn dispatch_task(
 
     // Update GitHub issue title with refined title (best-effort)
     if let Some(ref title) = refined_title {
-        let owner = config.owner.clone();
-        let repo = config.repo.clone();
-        let title = title.clone();
-        if let Err(err) = spawn_blocking_op(move || {
-            github::update_issue_title(&owner, &repo, issue_number, &title)
-        })
-        .await
+        if let Err(err) =
+            github::update_issue_title(&config.owner, &config.repo, issue_number, title).await
         {
             eprintln!("warning: failed to update issue title for {task_id}: {err}");
         }
@@ -1537,12 +1467,8 @@ async fn dispatch_task(
 
     // Update GitHub issue body with cleaned body (best-effort)
     if let Some(ref cleaned_body) = cleaned_body {
-        let owner = config.owner.clone();
-        let repo = config.repo.clone();
-        let cb = cleaned_body.clone();
         if let Err(err) =
-            spawn_blocking_op(move || github::update_issue_body(&owner, &repo, issue_number, &cb))
-                .await
+            github::update_issue_body(&config.owner, &config.repo, issue_number, cleaned_body).await
         {
             eprintln!("warning: failed to update issue body for {task_id}: {err}");
         }
@@ -1550,23 +1476,18 @@ async fn dispatch_task(
 
     // Post refined-prompt comment (best-effort)
     {
-        let owner = config.owner.clone();
-        let repo = config.repo.clone();
-        let tid = task_id.clone();
         let comment_body = match &refined_title {
             Some(title) => format!("**{title}**\n\n{idea}"),
             None => idea.clone(),
         };
-        if let Err(err) = spawn_blocking_op(move || {
-            github::post_idempotent_comment(
-                &owner,
-                &repo,
-                issue_number,
-                &tid,
-                "refined-prompt",
-                &comment_body,
-            )
-        })
+        if let Err(err) = github::post_idempotent_comment(
+            &config.owner,
+            &config.repo,
+            issue_number,
+            &task_id,
+            "refined-prompt",
+            &comment_body,
+        )
         .await
         {
             eprintln!("warning: failed to post refined-prompt comment for {task_id}: {err}");
@@ -1597,10 +1518,7 @@ async fn dispatch_task(
         );
         persisted_meta.pr_url
     } else {
-        let owner = config.owner.clone();
-        let repo = config.repo.clone();
-        let br = branch_name.clone();
-        match spawn_blocking_op(move || github::find_existing_pr(&owner, &repo, &br)).await {
+        match github::find_existing_pr(&config.owner, &config.repo, &branch_name).await {
             Ok(url) => url,
             Err(err) => {
                 eprintln!("dispatch: PR URL lookup failed for {task_id}: {err}");
@@ -1911,17 +1829,13 @@ async fn collect_children(
                 );
                 // Explicitly transition to terminal failure state so the
                 // issue does not remain stuck as ralph:in-progress.
-                let owner = config.owner.clone();
-                let repo = config.repo.clone();
-                if let Err(rollback_err) = spawn_blocking_op(move || {
-                    github::swap_lifecycle_label(
-                        &owner,
-                        &repo,
-                        issue_number,
-                        "ralph:in-progress",
-                        "ralph:failed",
-                    )
-                })
+                if let Err(rollback_err) = github::swap_lifecycle_label(
+                    &config.owner,
+                    &config.repo,
+                    issue_number,
+                    "ralph:in-progress",
+                    "ralph:failed",
+                )
                 .await
                 {
                     eprintln!(
@@ -1962,10 +1876,7 @@ async fn kill_aborted_children(
                 let owner = config.owner.clone();
                 let repo = config.repo.clone();
                 join_set.spawn(async move {
-                    let result = spawn_blocking_op(move || {
-                        github::fetch_issue_labels(&owner, &repo, issue_number)
-                    })
-                    .await;
+                    let result = github::fetch_issue_labels(&owner, &repo, issue_number).await;
                     (issue_number, task_id, result)
                 });
                 in_flight += 1;
@@ -2005,10 +1916,8 @@ async fn kill_aborted_children(
     for issue_number in to_kill {
         if let Some(mut handle) = children.remove(&issue_number) {
             let task_id = format_task_id(&config.owner, &config.repo, issue_number);
-            crate::daemon::process::terminate_process_group_blocking(
-                handle.pgid,
-                Duration::from_secs(10),
-            );
+            crate::daemon::process::terminate_process_group(handle.pgid, Duration::from_secs(10))
+                .await;
             handle.watcher_cancel.cancel();
             if let Some(join_handle) = handle.watcher_handle.take() {
                 await_watcher_with_timeout(join_handle, "artifact watcher", &task_id).await;
@@ -2162,21 +2071,16 @@ async fn complete_task_attempt(
 ) -> Result<()> {
     // Post completion comment (best-effort, idempotent)
     {
-        let owner = config.owner.clone();
-        let repo = config.repo.clone();
-        let tid = task_id.to_owned();
-        let phase = terminal_label.trim_start_matches("ralph:").to_owned();
-        let comment_body = format!("Task `{tid}` finished with status: **{phase}**.");
-        spawn_blocking_op(move || {
-            github::post_idempotent_comment(
-                &owner,
-                &repo,
-                issue_number,
-                &tid,
-                &phase,
-                &comment_body,
-            )
-        })
+        let phase = terminal_label.trim_start_matches("ralph:");
+        let comment_body = format!("Task `{task_id}` finished with status: **{phase}**.");
+        github::post_idempotent_comment(
+            &config.owner,
+            &config.repo,
+            issue_number,
+            task_id,
+            phase,
+            &comment_body,
+        )
         .await?;
     }
 
@@ -2193,15 +2097,14 @@ async fn complete_task_attempt(
     }
 
     // Swap lifecycle label: in-progress -> terminal (required)
-    {
-        let owner = config.owner.clone();
-        let repo = config.repo.clone();
-        let label = terminal_label.to_owned();
-        spawn_blocking_op(move || {
-            github::swap_lifecycle_label(&owner, &repo, issue_number, "ralph:in-progress", &label)
-        })
-        .await?;
-    }
+    github::swap_lifecycle_label(
+        &config.owner,
+        &config.repo,
+        issue_number,
+        "ralph:in-progress",
+        terminal_label,
+    )
+    .await?;
 
     // Worktree cleanup
     cleanup_worktree_for_terminal_state(config, task_id, terminal_label, repo_root_lock).await;
@@ -2357,10 +2260,7 @@ async fn auto_rebase_phase(
         let pr_url = if let Some(url) = cached_pr_url {
             url
         } else {
-            let owner = config.owner.clone();
-            let repo = config.repo.clone();
-            let br = branch.clone();
-            match spawn_blocking_op(move || github::find_existing_pr(&owner, &repo, &br)).await {
+            match github::find_existing_pr(&config.owner, &config.repo, branch).await {
                 Ok(Some(url)) => {
                     // Back-fill cached PR URL so future cycles skip the lookup.
                     if let Some(h) = children.get_mut(issue_number) {
@@ -2389,11 +2289,7 @@ async fn auto_rebase_phase(
 
         // Query PR merge info — on failure, break the loop (rate limit safety)
         let merge_info = {
-            let owner = config.owner.clone();
-            let repo = config.repo.clone();
-            match spawn_blocking_op(move || github::query_pr_merge_info(&owner, &repo, pr_number))
-                .await
-            {
+            match github::query_pr_merge_info(&config.owner, &config.repo, pr_number).await {
                 Ok(info) => info,
                 Err(err) => {
                     eprintln!(
@@ -2515,12 +2411,8 @@ async fn auto_rebase_phase(
                     let body = format!(
                         "{marker}\nAuto-rebase failed for task `{task_id}` (head: `{head_sha}`).\n\nError: {error}"
                     );
-                    let owner = config.owner.clone();
-                    let repo = config.repo.clone();
-                    let _ = spawn_blocking_op(move || {
-                        github::post_pr_comment(&owner, &repo, pr_number, &body)
-                    })
-                    .await;
+                    let _ = github::post_pr_comment(&config.owner, &config.repo, pr_number, &body)
+                        .await;
                     if let Some(h) = children.get_mut(&issue_number) {
                         h.last_rebase_failure_sha = Some(head_sha.clone());
                     }
@@ -2961,8 +2853,7 @@ pub(crate) async fn handle_pr_flow(
 ) -> Result<()> {
     // Resolve branch from worktree
     let branch = {
-        let wt = wt_path.to_path_buf();
-        match spawn_blocking_op(move || github::current_branch(&wt)).await {
+        match github::current_branch(wt_path).await {
             Ok(b) => b,
             Err(err) => {
                 eprintln!("warning: failed to read current branch for {task_id}: {err}");
@@ -2973,10 +2864,7 @@ pub(crate) async fn handle_pr_flow(
 
     // Step 0: Check for existing PR (used by both no-diff and update paths)
     let existing_pr_url = {
-        let owner = config.owner.clone();
-        let repo = config.repo.clone();
-        let br = branch.clone();
-        match spawn_blocking_op(move || github::find_existing_pr(&owner, &repo, &br)).await {
+        match github::find_existing_pr(&config.owner, &config.repo, &branch).await {
             Ok(url) => url,
             Err(err) => {
                 eprintln!("warning: failed to check for existing PR: {err}");
@@ -2987,9 +2875,7 @@ pub(crate) async fn handle_pr_flow(
 
     // Step 1: Check if there's a diff against the configured base branch
     let has_changes = {
-        let wt = wt_path.to_path_buf();
-        let base = config.base_branch.clone();
-        match spawn_blocking_op(move || github::has_diff_with_base(&wt, Some(&base))).await {
+        match github::has_diff_with_base(wt_path, Some(&config.base_branch)).await {
             Ok(v) => v,
             Err(err) => {
                 eprintln!("warning: failed to check diff for {task_id}: {err}");
@@ -2999,26 +2885,15 @@ pub(crate) async fn handle_pr_flow(
     };
 
     if !has_changes {
-        let owner = config.owner.clone();
-        let repo = config.repo.clone();
         if let Some(url) = existing_pr_url.as_ref() {
             if let Some(pr_number) = github::extract_pr_number(url) {
-                let owner_for_draft = owner.clone();
-                let repo_for_draft = repo.clone();
-                let pr_is_draft = spawn_blocking_op(move || {
-                    github::is_pr_draft(&owner_for_draft, &repo_for_draft, pr_number)
-                })
-                .await?;
+                let pr_is_draft =
+                    github::is_pr_draft(&config.owner, &config.repo, pr_number).await?;
 
                 if decide_draft_pr_transition(has_changes, pr_is_draft, "ralph:completed")
                     == DraftPrTransition::CloseNoDiff
                 {
-                    let owner_for_close = owner.clone();
-                    let repo_for_close = repo.clone();
-                    spawn_blocking_op(move || {
-                        github::close_pr(&owner_for_close, &repo_for_close, pr_number)
-                    })
-                    .await?;
+                    github::close_pr(&config.owner, &config.repo, pr_number).await?;
 
                     // Clear persisted PR URL so future flows do not reuse closed draft PRs.
                     save_task_metadata(
@@ -3039,19 +2914,14 @@ pub(crate) async fn handle_pr_flow(
             body.push_str(" Existing draft PR was closed if it was still in draft state.");
         }
 
-        let owner_for_comment = config.owner.clone();
-        let repo = config.repo.clone();
-        let tid = task_id.to_owned();
-        if let Err(err) = spawn_blocking_op(move || {
-            github::post_idempotent_comment(
-                &owner_for_comment,
-                &repo,
-                issue_number,
-                &tid,
-                "no-diff",
-                &body,
-            )
-        })
+        if let Err(err) = github::post_idempotent_comment(
+            &config.owner,
+            &config.repo,
+            issue_number,
+            task_id,
+            "no-diff",
+            &body,
+        )
         .await
         {
             eprintln!("warning: failed to post no-diff comment for {task_id}: {err}");
@@ -3061,8 +2931,7 @@ pub(crate) async fn handle_pr_flow(
 
     // Skip push/PR flow when no origin remote exists
     {
-        let wt = wt_path.to_path_buf();
-        let has_origin = match spawn_blocking_op(move || github::has_origin_remote(&wt)).await {
+        let has_origin = match github::has_origin_remote(wt_path).await {
             Ok(v) => v,
             Err(err) => {
                 eprintln!(
@@ -3078,16 +2947,11 @@ pub(crate) async fn handle_pr_flow(
     }
 
     // Step 2: Push branch
-    {
-        let wt = wt_path.to_path_buf();
-        let br = branch.clone();
-        spawn_blocking_op(move || github::push_branch_with_retry(&wt, &br)).await?;
-    }
+    github::push_branch_with_retry(wt_path, &branch).await?;
 
     // Step 3: Gather context
     let diff_stat: Option<String> = {
-        let wt = wt_path.to_path_buf();
-        match spawn_blocking_op(move || github::diff_stat(&wt)).await {
+        match github::diff_stat(wt_path).await {
             Ok(stat) => stat,
             Err(err) => {
                 eprintln!("warning: diff stat failed for {task_id}: {err}; using fallback");
@@ -3098,10 +2962,7 @@ pub(crate) async fn handle_pr_flow(
 
     // Fetch raw_idea from GitHub for PR body context
     let raw_idea = {
-        let owner = config.owner.clone();
-        let repo = config.repo.clone();
-        match spawn_blocking_op(move || github::fetch_issue_body(&owner, &repo, issue_number)).await
-        {
+        match github::fetch_issue_body(&config.owner, &config.repo, issue_number).await {
             Ok((title, body)) => Some(compose_raw_idea(&title, body.as_deref())),
             Err(_) => None,
         }
@@ -3128,10 +2989,7 @@ pub(crate) async fn handle_pr_flow(
 
     // Try to get refined title from GitHub issue
     let refined_title = {
-        let owner = config.owner.clone();
-        let repo = config.repo.clone();
-        match spawn_blocking_op(move || github::fetch_issue_body(&owner, &repo, issue_number)).await
-        {
+        match github::fetch_issue_body(&config.owner, &config.repo, issue_number).await {
             Ok((title, _)) => {
                 if title.is_empty() {
                     None
@@ -3150,14 +3008,8 @@ pub(crate) async fn handle_pr_flow(
     match existing_pr_url {
         Some(url) => {
             eprintln!("editing existing PR for {task_id}: {url}");
-            let url_for_edit = url.clone();
-            let title_clone = title.clone();
             let body_path = body_file.path().to_path_buf();
-            match spawn_blocking_op(move || {
-                github::edit_pr(&url_for_edit, &title_clone, &body_path)
-            })
-            .await
-            {
+            match github::edit_pr(&url, &title, &body_path).await {
                 Ok(()) => {}
                 Err(err) => {
                     return Err(RalphError::Orchestration(format!(
@@ -3167,8 +3019,6 @@ pub(crate) async fn handle_pr_flow(
             }
 
             if let Some(pr_number) = github::extract_pr_number(&url) {
-                let owner_for_draft = config.owner.clone();
-                let repo_for_draft = config.repo.clone();
                 save_task_metadata(
                     &config.workspace_root,
                     task_id,
@@ -3176,41 +3026,27 @@ pub(crate) async fn handle_pr_flow(
                         pr_url: Some(url.clone()),
                     },
                 );
-                let pr_is_draft = spawn_blocking_op(move || {
-                    github::is_pr_draft(&owner_for_draft, &repo_for_draft, pr_number)
-                })
-                .await?;
+                let pr_is_draft =
+                    github::is_pr_draft(&config.owner, &config.repo, pr_number).await?;
 
                 if decide_draft_pr_transition(has_changes, pr_is_draft, "ralph:completed")
                     == DraftPrTransition::MarkReady
                 {
-                    let owner_for_ready = config.owner.clone();
-                    let repo_for_ready = config.repo.clone();
-                    spawn_blocking_op(move || {
-                        github::mark_pr_ready(&owner_for_ready, &repo_for_ready, pr_number)
-                    })
-                    .await?;
+                    github::mark_pr_ready(&config.owner, &config.repo, pr_number).await?;
                 }
             }
         }
         None => {
-            let owner = config.owner.clone();
-            let repo = config.repo.clone();
-            let br = branch.clone();
-            let title_clone = title.clone();
             let body_path = body_file.path().to_path_buf();
-            let base = config.base_branch.clone();
-            match spawn_blocking_op(move || {
-                github::create_pr_with_body_file(
-                    &owner,
-                    &repo,
-                    &br,
-                    &title_clone,
-                    &body_path,
-                    Some(&base),
-                    false,
-                )
-            })
+            match github::create_pr_with_body_file(
+                &config.owner,
+                &config.repo,
+                &branch,
+                &title,
+                &body_path,
+                Some(&config.base_branch),
+                false,
+            )
             .await
             {
                 Ok(url) => {

--- a/src/daemon/worktree.rs
+++ b/src/daemon/worktree.rs
@@ -4,9 +4,23 @@ use std::process::Command;
 use std::sync::Arc;
 use tokio::sync::Semaphore;
 
-use crate::daemon::github::has_origin_remote;
 use crate::error::RalphError;
 use crate::Result;
+
+/// Synchronous check for whether the repo has an `origin` remote.
+///
+/// This is a sync equivalent of `github::has_origin_remote` for use in
+/// sync worktree functions that cannot call async code.
+fn has_origin_remote_sync(repo_root: &Path) -> Result<bool> {
+    let output = Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .current_dir(repo_root)
+        .output()
+        .map_err(|err| {
+            RalphError::Orchestration(format!("failed to check origin remote: {err}"))
+        })?;
+    Ok(output.status.success())
+}
 
 /// Return the base directory for daemon worktrees.
 pub fn worktrees_dir(workspace_root: &Path) -> PathBuf {
@@ -49,7 +63,7 @@ pub fn create_worktree(
 
     // Remote-first: fetch and use origin/HEAD as base ref, falling back to
     // origin/main, origin/master, or local HEAD for fresh/empty repos.
-    match has_origin_remote(repo_root) {
+    match has_origin_remote_sync(repo_root) {
         Ok(has_origin) => {
             if has_origin {
                 if let Err(err) = fetch_origin(repo_root, task_id) {

--- a/src/validate/tests_daemon.rs
+++ b/src/validate/tests_daemon.rs
@@ -2144,7 +2144,10 @@ fn daemon_has_diff_invalid_base_returns_false(_h: &RalphHarness) -> TestResult {
         git(&repo_root, &["commit", "-m", "initial"]);
         git(&repo_root, &["branch", "-M", "trunk"]);
 
-        let has_changes = github::has_diff(&repo_root).expect("has_diff should not hard-fail");
+        let has_changes = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(github::has_diff(&repo_root))
+            .expect("has_diff should not hard-fail");
         assert!(
             !has_changes,
             "invalid base revision in single-commit repo should be treated as no diff"
@@ -3774,13 +3777,14 @@ exit 1
             .write_mock_script("gh", &gh_script)
             .expect("write mock gh script");
 
-        let result = github::add_label_with_retry_with_gh_bin(
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let result = rt.block_on(github::add_label_with_retry_with_gh_bin(
             gh_bin.to_str().expect("mock gh path should be UTF-8"),
             "acme",
             "widgets",
             1,
             "ralph:in-progress",
-        );
+        ));
 
         assert!(
             result.is_ok(),

--- a/src/validate/tests_pr_lifecycle.rs
+++ b/src/validate/tests_pr_lifecycle.rs
@@ -145,7 +145,7 @@ fn draft_pr_marked_ready_transition(h: &RalphHarness) -> TestResult {
         unsafe { std::env::set_var("PATH", composed) };
 
         let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_time()
+            .enable_all()
             .build()
             .expect("build runtime");
 
@@ -210,7 +210,7 @@ fn no_diff_draft_pr_closed_transition(h: &RalphHarness) -> TestResult {
         );
 
         let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_time()
+            .enable_all()
             .build()
             .expect("build runtime");
 
@@ -242,7 +242,7 @@ fn complete_task_retries_transient_up_to_three(_h: &RalphHarness) -> TestResult 
         let attempts_c = Arc::clone(&attempts);
         let sleeps_c = Arc::clone(&sleeps);
         let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_time()
+            .enable_all()
             .build()
             .expect("build runtime");
 
@@ -295,7 +295,7 @@ fn complete_task_no_retry_terminal(_h: &RalphHarness) -> TestResult {
         let attempts_c = Arc::clone(&attempts);
         let sleeps_c = Arc::clone(&sleeps);
         let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_time()
+            .enable_all()
             .build()
             .expect("build runtime");
 

--- a/src/validate/tests_pr_runtime.rs
+++ b/src/validate/tests_pr_runtime.rs
@@ -78,7 +78,7 @@ fn draft_watcher_creates_draft_when_branch_ahead(h: &RalphHarness) -> TestResult
         unsafe { std::env::set_var("PATH", composed) };
 
         let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_time()
+            .enable_all()
             .build()
             .expect("build runtime");
 
@@ -147,7 +147,7 @@ fn draft_watcher_pushes_before_create(h: &RalphHarness) -> TestResult {
         unsafe { std::env::set_var("PATH", composed) };
 
         let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_time()
+            .enable_all()
             .build()
             .expect("build runtime");
 
@@ -209,7 +209,7 @@ fn draft_watcher_exits_cleanly_on_cancellation(h: &RalphHarness) -> TestResult {
         let poll_guard = EnvVarRestoreGuard::new("RALPH_DRAFT_PR_WATCH_POLL_SECS", original_poll);
 
         let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_time()
+            .enable_all()
             .build()
             .expect("build runtime");
 
@@ -466,15 +466,17 @@ fn create_pr_honors_draft_true(_h: &RalphHarness) -> TestResult {
         let composed = format!("{}:{}", mock_dir.display(), original_path);
         unsafe { std::env::set_var("PATH", &composed) };
 
-        let url = crate::daemon::github::create_pr(
-            "acme",
-            "widgets",
-            "ralph/issue-93",
-            "Draft PR title",
-            "Body",
-            true,
-        )
-        .expect("create_pr draft=true");
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let url = rt
+            .block_on(crate::daemon::github::create_pr(
+                "acme",
+                "widgets",
+                "ralph/issue-93",
+                "Draft PR title",
+                "Body",
+                true,
+            ))
+            .expect("create_pr draft=true");
         assert_eq!(url, "https://github.com/acme/widgets/pull/99");
 
         let logged = fs::read_to_string(&args_log).expect("read gh args log");
@@ -483,15 +485,16 @@ fn create_pr_honors_draft_true(_h: &RalphHarness) -> TestResult {
             "expected --draft arg in gh invocation, got: {logged}"
         );
 
-        let _ = crate::daemon::github::create_pr(
-            "acme",
-            "widgets",
-            "ralph/issue-93",
-            "Ready PR",
-            "Body",
-            false,
-        )
-        .expect("create_pr draft=false");
+        let _ = rt
+            .block_on(crate::daemon::github::create_pr(
+                "acme",
+                "widgets",
+                "ralph/issue-93",
+                "Ready PR",
+                "Body",
+                false,
+            ))
+            .expect("create_pr draft=false");
         let logged_after =
             fs::read_to_string(&args_log).expect("read gh args log after second call");
         let draft_count = logged_after
@@ -546,7 +549,7 @@ fn draft_watcher_fallback_base_when_configured_missing(h: &RalphHarness) -> Test
         unsafe { std::env::set_var("PATH", composed) };
 
         let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_time()
+            .enable_all()
             .build()
             .expect("build runtime");
 


### PR DESCRIPTION
## Summary

- Convert all 41 `std::process::Command` calls in `github.rs` to `tokio::process::Command` (async)
- Remove `spawn_blocking_op` wrappers from CLI daemon commands (`status`, `abort`, `retrigger`) and runtime dispatch
- Delete `terminate_process_group_blocking` that caused a nested-runtime panic (#182)
- Enable IO on conformance test runtimes (`.enable_time()` → `.enable_all()`) so `tokio::process::Command` works

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` passes
- [x] `nix build` passes (386/386 conformance tests, including the 8 previously failing PR runtime/lifecycle tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)