### PR TITLE
fix: add -f flag to git worktree add for branch reuse

### DIFF
--- a/src/daemon/worktree.rs
+++ b/src/daemon/worktree.rs
@@ -128,7 +128,13 @@ pub fn create_worktree(
     let output = if branch_exists {
         // Reuse existing branch
         Command::new("git")
-            .args(["worktree", "add", &wt_path.to_string_lossy(), &branch_name])
+            .args([
+                "worktree",
+                "add",
+                "-f",
+                &wt_path.to_string_lossy(),
+                &branch_name,
+            ])
             .current_dir(repo_root)
             .output()
     } else {


### PR DESCRIPTION
## Summary

- Add `-f` flag to `git worktree add` when reusing an existing branch, preventing failure if the branch is already checked out in another worktree
- Addresses Codex review feedback on PR #185

## Test plan

- [x] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)