### PR TITLE
Raise quick-dev default max_review_iterations from 5 to 30

### DIFF
--- a/src/cli/rollback.rs
+++ b/src/cli/rollback.rs
@@ -83,14 +83,15 @@ pub fn execute(args: RollbackArgs) -> Result<()> {
         .parent()
         .filter(|r| is_git_repo(r))
         .and_then(|repo_root| {
-            let branch =
-                resolve_branch_name(&workspace.config.git.branch_format, &project_id);
-            list_ralph_commits(repo_root, &branch).ok().and_then(|commits| {
-                commits
-                    .iter()
-                    .find(|c| c.project_id == project_id)
-                    .and_then(|c| c.commit_hash.clone())
-            })
+            let branch = resolve_branch_name(&workspace.config.git.branch_format, &project_id);
+            list_ralph_commits(repo_root, &branch)
+                .ok()
+                .and_then(|commits| {
+                    commits
+                        .iter()
+                        .find(|c| c.project_id == project_id)
+                        .and_then(|c| c.commit_hash.clone())
+                })
         });
 
     // Dry-run: resolve ref early for display (read-only, no branch mutations).
@@ -105,8 +106,7 @@ pub fn execute(args: RollbackArgs) -> Result<()> {
                 // locally.  If it would need recovery (create from remote-
                 // tracking / fetch) we cannot determine the ref without side
                 // effects, so print a placeholder instead of a wrong value.
-                let branch =
-                    resolve_branch_name(&workspace.config.git.branch_format, &project_id);
+                let branch = resolve_branch_name(&workspace.config.git.branch_format, &project_id);
                 if branch_exists(repo_root, &branch)? {
                     let reference = resolve_hard_reset_ref(
                         &workspace,

--- a/src/project/lifecycle.rs
+++ b/src/project/lifecycle.rs
@@ -2324,8 +2324,7 @@ mod tests {
         }
 
         // Original checkpoint commits (from before rollback).
-        let msg1 =
-            build_ralph_commit_message("test-proj", 1, Phase::Planning, Phase::Implementing);
+        let msg1 = build_ralph_commit_message("test-proj", 1, Phase::Planning, Phase::Implementing);
         commit_empty_with_msg(&repo, &msg1);
         git_ok(&repo, &["push", "origin", "HEAD:ralph/test-proj"]);
 

--- a/src/validate/tests_commands.rs
+++ b/src/validate/tests_commands.rs
@@ -658,9 +658,7 @@ fn rollback_hard_missing_branch(h: &RalphHarness) -> TestResult {
         assert_exit_code(&output, 0);
 
         // Verify state rolled back and HEAD moved.
-        let state = h
-            .load_state(project_id)
-            .expect("load_state after rollback");
+        let state = h.load_state(project_id).expect("load_state after rollback");
         let loops = state["loops"].as_array().expect("loops should be an array");
         assert_eq!(
             loops.len(),
@@ -700,7 +698,11 @@ fn rollback_hard_missing_branch(h: &RalphHarness) -> TestResult {
         assert!(status.success(), "git branch -D failed (2)");
 
         let _ = Command::new("git")
-            .args(["update-ref", "-d", &format!("refs/remotes/origin/{branch2}")])
+            .args([
+                "update-ref",
+                "-d",
+                &format!("refs/remotes/origin/{branch2}"),
+            ])
             .current_dir(&h.repo_root)
             .status();
 
@@ -1567,15 +1569,11 @@ fn rollback_removes_ceiling_hidden_loops(h: &RalphHarness) -> TestResult {
 
         // Verify both loop dirs exist before manipulation.
         assert!(
-            h.loop_dir(project_id, 1)
-                .expect("loop_dir")
-                .is_some(),
+            h.loop_dir(project_id, 1).expect("loop_dir").is_some(),
             "loop-1 dir should exist after run"
         );
         assert!(
-            h.loop_dir(project_id, 2)
-                .expect("loop_dir")
-                .is_some(),
+            h.loop_dir(project_id, 2).expect("loop_dir").is_some(),
             "loop-2 dir should exist after run"
         );
 

--- a/src/workflow/quick_dev_orchestrator.rs
+++ b/src/workflow/quick_dev_orchestrator.rs
@@ -52,7 +52,7 @@ pub struct QuickDevRunOptions {
     pub max_final_review_retries: Option<u32>,
 }
 
-const DEFAULT_MAX_REVIEW_ITERATIONS: u32 = 5;
+const DEFAULT_MAX_REVIEW_ITERATIONS: u32 = 30;
 const DEFAULT_MAX_FINAL_REVIEW_RETRIES: u32 = 15;
 
 #[derive(Debug, Clone)]
@@ -1660,7 +1660,7 @@ mod tests {
 
     #[test]
     fn default_max_values() {
-        assert_eq!(DEFAULT_MAX_REVIEW_ITERATIONS, 5);
+        assert_eq!(DEFAULT_MAX_REVIEW_ITERATIONS, 30);
         assert_eq!(DEFAULT_MAX_FINAL_REVIEW_RETRIES, 15);
     }
 


### PR DESCRIPTION
## Summary
- Raises `DEFAULT_MAX_REVIEW_ITERATIONS` in quick-dev orchestrator from 5 to 30, aligning with the full workflow default
- Prevents premature skip-to-final-review on complex tasks where codex needs more review rounds to converge

🤖 Generated with [Claude Code](https://claude.com/claude-code)