### PR TITLE
Raise max_final_review_restarts default from 15 to 25

### DIFF
--- a/.ralph/ralph.toml
+++ b/.ralph/ralph.toml
@@ -118,7 +118,7 @@ final_review_backends = [
 final_review_arbiter_backend = "codex"
 final_review_min_reviewers = 2
 final_review_consensus_threshold = 1.0
-max_final_review_restarts = 15
+max_final_review_restarts = 25
 completion_backends = [
     "claude",
     "codex",

--- a/src/config/global.rs
+++ b/src/config/global.rs
@@ -1003,7 +1003,7 @@ fn default_final_review_consensus_threshold() -> f64 {
 }
 
 fn default_max_final_review_restarts() -> u32 {
-    15
+    25
 }
 
 fn default_completion_backends() -> Vec<String> {
@@ -2278,7 +2278,7 @@ base_branch = "master"
         assert_eq!(config.workflow.final_review_arbiter_backend, "claude");
         assert_eq!(config.workflow.final_review_min_reviewers, 2);
         assert_eq!(config.workflow.final_review_consensus_threshold, 1.0);
-        assert_eq!(config.workflow.max_final_review_restarts, 15);
+        assert_eq!(config.workflow.max_final_review_restarts, 25);
         assert_eq!(config.workflow.max_review_history_entries_in_prompt, 3);
         assert_eq!(config.workflow.max_qa_history_entries_in_prompt, 2);
         assert!(!config.workflow.include_history_when_session_reuse_enabled);


### PR DESCRIPTION
## Summary
- Increase `max_final_review_restarts` default from 15 to 25 to give complex tasks more iterations to converge
- Task #184 (in-process tokio migration) demonstrated that 15 iterations was insufficient for large refactors where the final reviewer keeps finding diminishing-returns issues

## Test plan
- [x] `cargo test` passes
- [x] `nix build` passes (verified via pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)