### PR TITLE
simplify: strip final reviewer prompt to minimal essentials

### DIFF
--- a/src/prompts/templates.rs
+++ b/src/prompts/templates.rs
@@ -116,6 +116,8 @@ CRITICAL FORMAT REQUIREMENTS:
 - Include ALL required H2 sections
 - No preamble or commentary before the H1
 
+`<TS>` is a 14-digit timestamp in `YYYYMMDDHHMMSS` format (digits only, no separators).
+
 If this is the first implementation pass, output `<TS>-impl-notes.md` in this format:
 
 # Implementation Notes
@@ -394,75 +396,38 @@ If any checks fail:
 }
 
 pub fn default_final_reviewer_template() -> &'static str {
-    r#"You are a final reviewer auditing a completed project for correctness, safety, and robustness.
+    r#"You are a code reviewer. Review the changes in this project for correctness, safety, and robustness.
 
-You have full access to the project codebase via your tools (file reading, search, shell commands). The specification and plan are already committed to git — do NOT rely on a separate spec document. Instead, read the actual source code.
+Run this to see all changes:
+{{review_diff_command}}
 
-## HOW TO WRITE AMENDMENT BODIES
+Then read the key implementation files end-to-end. For each issue found, cite specific files and line numbers.
 
-- Cite specific files, line numbers, and function names.
-- Assign an accurate severity using a priority tag (`[P0]`–`[P3]`) at the start of the Problem section.
-- Keep the Problem section to 1–2 paragraphs maximum.
-- Do not include code blocks longer than 3 lines; reference files instead.
-- State the required reproduction scenario or failing condition.
-- Use matter-of-fact tone — no hedging, no rhetorical questions.
-- Each amendment must be immediately graspable by a developer unfamiliar with the review history.
-- Do not manufacture findings — but do not suppress real ones either.
-
-## PRIORITY LEVELS
-
-- `[P0]` — Blocking: breaks correctness or safety in a way that cannot ship. Must be fixed before merge.
-- `[P1]` — Urgent: significant bug, data-loss risk, or security concern that should be fixed promptly.
-- `[P2]` — Normal: real issue that should be addressed but does not block merge.
-- `[P3]` — Low: minor improvement, edge-case hardening, or cleanup worth noting.
-
-## ADDITIONAL GUIDELINES
-
-- Style issues: only flag if they obscure meaning or violate documented project standards.
-- One amendment per discrete issue — do not bundle unrelated problems.
-- For concurrent/parallel code: verify each worker has properly isolated resources (working directories, file handles, state). Check whether panic/error paths persist failure state or silently drop it.
-- For tests: verify assertions actually prove what test names claim. Look for tests that pass for the wrong reason or miss asserting on the component that fails.
-- Check for stray files, dead code, or unintended changes outside scope.
-- You are NOT limited to the original spec scope; any real bug or safety issue is valid.
-
-## YOUR WORKFLOW
-
-1. Run `{{review_diff_command}}` to see all source changes relative to `{{base_branch}}`, then read key files to review them.
-2. Read key implementation files and tests end-to-end — do not rely only on the diff.
-3. For each potential finding, verify it against the actual source code.
-4. Produce your output in the format below.
-
-CRITICAL FORMAT REQUIREMENTS:
-- Return markdown body only (no YAML frontmatter)
-- Your response MUST begin with the correct H1 heading as the VERY FIRST LINE
-- Include ALL required H2 sections
-- No preamble or commentary before the H1
-
-If no changes are needed:
+If no issues:
 
 # Final Review: NO AMENDMENTS
 
 ## Summary
-<why the project is complete and correct — cite specific source files you verified>
+<why the project is correct>
 
 ---
 
-If changes are needed:
+If issues found:
 
 # Final Review: AMENDMENTS
 
 ## Amendment: <ID>
 
 ### Problem
-<[P0]–[P3] priority tag> <what is wrong or missing — cite source files and line numbers>
+<what is wrong — cite files and lines>
 
 ### Proposed Change
-<what should be changed>
+<what should change>
 
 ### Affected Files
 - `path/to/file` - <what changes>
 
-(repeat ## Amendment: <ID> for each amendment)
+(repeat for each issue)
 
 ---
 
@@ -470,6 +435,9 @@ If changes are needed:
 
 ## System Guardrails
 {{system_guardrails}}
+
+## Master Prompt
+{{master_prompt}}
 "#
 }
 

--- a/src/validate/mock_scripts.rs
+++ b/src/validate/mock_scripts.rs
@@ -318,7 +318,7 @@ EOF
   fi
   echo "implemented" > mock_file.txt
   git add mock_file.txt
-elif grep -q "You are a final reviewer auditing a completed project for correctness, safety, and robustness." <<< "$INPUT"; then
+elif grep -q "You are a code reviewer. Review" <<< "$INPUT"; then
   cat <<'EOF'
 # Final Review: NO AMENDMENTS
 
@@ -461,7 +461,7 @@ EOF
   # Create stray impl artifacts at worktree root
   echo "stray notes" > 20260304120000-impl-notes.md
   echo "stray response" > 20260304120000-impl-response-001.md
-elif grep -q "You are a final reviewer auditing a completed project for correctness, safety, and robustness." <<< "$INPUT"; then
+elif grep -q "You are a code reviewer. Review" <<< "$INPUT"; then
   cat <<'EOF'
 # Final Review: NO AMENDMENTS
 
@@ -647,7 +647,7 @@ EOF
   fi
   echo "implemented" > mock_file.txt
   git add mock_file.txt
-elif grep -q "You are a final reviewer auditing a completed project for correctness, safety, and robustness." <<< "$INPUT"; then
+elif grep -q "You are a code reviewer. Review" <<< "$INPUT"; then
   cat <<'EOF'
 # Final Review: NO AMENDMENTS
 
@@ -791,7 +791,7 @@ EOF
   fi
   echo "cwd-ok" > cwd_test.txt
   git add cwd_test.txt
-elif grep -q "You are a final reviewer auditing a completed project for correctness, safety, and robustness." <<< "$INPUT"; then
+elif grep -q "You are a code reviewer. Review" <<< "$INPUT"; then
   cat <<'EOF'
 # Final Review: NO AMENDMENTS
 
@@ -3397,7 +3397,7 @@ esac
 /// Responds to quick-dev prompts that the implementer handles:
 /// - `plan-and-implement phase` → implementation notes output + creates `mock_file.txt`
 /// - `apply-fixes phase` → implementation response
-/// - `final reviewer auditing` → `# Final Review: NO AMENDMENTS`
+/// - `You are a code reviewer. Review` → `# Final Review: NO AMENDMENTS`
 ///
 /// Environment variable `QUICK_DEV_FINAL_REVIEW_RESULT` controls the final-review
 /// response: "NO_AMENDMENTS" (default) or "AMENDMENTS".
@@ -3434,7 +3434,7 @@ elif grep -q "quick-dev apply-fixes phase" <<< "$INPUT"; then
 EOF
   echo "quick-dev-fixed" >> mock_file.txt
   git add mock_file.txt
-elif grep -q "final reviewer auditing" <<< "$INPUT"; then
+elif grep -q "You are a code reviewer. Review" <<< "$INPUT"; then
   result="${QUICK_DEV_FINAL_REVIEW_RESULT:-NO_AMENDMENTS}"
   if [ "$result" = "AMENDMENTS" ]; then
     cat <<'EOF'
@@ -3463,7 +3463,7 @@ fi
 ///
 /// Responds to quick-dev prompts that the reviewer handles:
 /// - `quick-dev reviewer` → `# Review: SATISFIED`
-/// - `final reviewer auditing` → `# Final Review: NO AMENDMENTS`
+/// - `You are a code reviewer. Review` → `# Final Review: NO AMENDMENTS`
 ///
 /// Environment variables:
 /// - `QUICK_DEV_REVIEW_RESULT`: "SATISFIED" (default) or "CHANGES REQUESTED"
@@ -3491,7 +3491,7 @@ EOF
 Implementation looks good, no changes needed.
 EOF
   fi
-elif grep -q "final reviewer auditing" <<< "$INPUT"; then
+elif grep -q "You are a code reviewer. Review" <<< "$INPUT"; then
   result="${QUICK_DEV_FINAL_REVIEW_RESULT:-NO_AMENDMENTS}"
   if [ "$result" = "AMENDMENTS" ]; then
     cat <<'EOF'
@@ -3531,7 +3531,7 @@ if grep -q "quick-dev reviewer" <<< "$INPUT"; then
 ## Required Changes
 - Always-reject mock: changes requested every time.
 EOF
-elif grep -q "final reviewer auditing" <<< "$INPUT"; then
+elif grep -q "You are a code reviewer. Review" <<< "$INPUT"; then
   cat <<'EOF'
 # Final Review: NO AMENDMENTS
 
@@ -3574,7 +3574,7 @@ EOF
 - Fix the initial implementation issue.
 EOF
   fi
-elif grep -q "final reviewer auditing" <<< "$INPUT"; then
+elif grep -q "You are a code reviewer. Review" <<< "$INPUT"; then
   cat <<'EOF'
 # Final Review: NO AMENDMENTS
 
@@ -3632,7 +3632,7 @@ elif grep -q "quick-dev reviewer" <<< "$INPUT"; then
 ## Summary
 Implementation satisfactory.
 EOF
-elif grep -q "final reviewer auditing" <<< "$INPUT"; then
+elif grep -q "You are a code reviewer. Review" <<< "$INPUT"; then
   count=0
   if [ -f "$STATE" ]; then
     count="$(cat "$STATE")"
@@ -3702,7 +3702,7 @@ elif grep -q "quick-dev reviewer" <<< "$INPUT"; then
 ## Summary
 OK.
 EOF
-elif grep -q "final reviewer auditing" <<< "$INPUT"; then
+elif grep -q "You are a code reviewer. Review" <<< "$INPUT"; then
   cat <<'EOF'
 # Final Review: AMENDMENTS
 
@@ -3901,7 +3901,7 @@ EOF
   # Create more stray files on second iteration
   echo "stray notes 2" > 20260304130000-impl-notes.md
   echo "stray response 2" > 20260304130000-impl-response-002.md
-elif grep -q "final reviewer auditing" <<< "$INPUT"; then
+elif grep -q "You are a code reviewer. Review" <<< "$INPUT"; then
   result="${QUICK_DEV_FINAL_REVIEW_RESULT:-NO_AMENDMENTS}"
   if [ "$result" = "AMENDMENTS" ]; then
     cat <<'EOF'

--- a/src/validate/tests_completion_panel.rs
+++ b/src/validate/tests_completion_panel.rs
@@ -117,7 +117,7 @@ EOF
   fi
   echo "implemented" > mock_file.txt
   git add mock_file.txt
-elif printf '%s' "$INPUT" | grep -q "You are a final reviewer auditing a completed project for correctness, safety, and robustness."; then
+elif printf '%s' "$INPUT" | grep -q "You are a code reviewer. Review"; then
   cat <<'EOF'
 # Final Review: NO AMENDMENTS
 
@@ -250,7 +250,7 @@ EOF
   fi
   echo "implemented" > mock_file.txt
   git add mock_file.txt
-elif printf '%s' "$INPUT" | grep -q "You are a final reviewer auditing a completed project for correctness, safety, and robustness."; then
+elif printf '%s' "$INPUT" | grep -q "You are a code reviewer. Review"; then
   cat <<'EOF'
 # Final Review: NO AMENDMENTS
 

--- a/src/validate/tests_final_review.rs
+++ b/src/validate/tests_final_review.rs
@@ -199,7 +199,7 @@ elif [[ "$prompt" == *"You are a QA engineer"* ]]; then
 ## Acceptance Criteria Verification
 All good.
 EOF
-elif [[ "$prompt" == *"You are a final reviewer auditing a completed project for correctness, safety, and robustness."* ]]; then
+elif [[ "$prompt" == *"You are a code reviewer. Review"* ]]; then
   total=$(inc_counter "final_reviewer_total")
   round=$(( (total - 1) / 2 + 1 ))
   slot=$(( (total - 1) % 2 + 1 ))
@@ -451,7 +451,7 @@ elif [[ "$prompt" == *"You are a QA engineer validating overall project acceptan
 ## Acceptance Criteria Verification
 All good.
 EOF
-elif [[ "$prompt" == *"You are a final reviewer auditing a completed project for correctness, safety, and robustness."* ]]; then
+elif [[ "$prompt" == *"You are a code reviewer. Review"* ]]; then
   total=$(inc_counter "final_reviewer_total")
   slot=$(( (total - 1) % 2 + 1 ))
   cat <<EOF

--- a/src/validate/tests_final_review_cap_skip.rs
+++ b/src/validate/tests_final_review_cap_skip.rs
@@ -227,7 +227,7 @@ elif [[ "$prompt" == *"You are a QA engineer"* ]]; then
 ## Acceptance Criteria Verification
 All good.
 EOF
-elif [[ "$prompt" == *"You are a final reviewer auditing a completed project for correctness, safety, and robustness."* ]] \
+elif [[ "$prompt" == *"You are a code reviewer. Review"* ]] \
   || [[ "$prompt" == *"You are a technical evaluator assessing proposed amendments from final reviewers."* ]] \
   || [[ "$prompt" == *"You are a reviewer voting on proposed amendments after considering the planner's positions."* ]] \
   || [[ "$prompt" == *"You are the arbiter resolving disputed amendments where reviewers and planner disagree."* ]]; then
@@ -280,7 +280,7 @@ elif [[ "$prompt" == *"You are a QA engineer"* ]]; then
 ## Acceptance Criteria Verification
 All good.
 EOF
-elif [[ "$prompt" == *"You are a final reviewer auditing a completed project for correctness, safety, and robustness."* ]]; then
+elif [[ "$prompt" == *"You are a code reviewer. Review"* ]]; then
   cat <<'EOF'
 # Final Review: NO AMENDMENTS
 

--- a/src/validate/tests_prompt_review_panel.rs
+++ b/src/validate/tests_prompt_review_panel.rs
@@ -156,7 +156,7 @@ elif printf '%s' "$INPUT" | grep -q "You are a QA engineer"; then
 ## Acceptance Criteria Verification
 All acceptance criteria verified by mock QA.
 EOF
-elif printf '%s' "$INPUT" | grep -q "You are a final reviewer auditing a completed project for correctness, safety, and robustness."; then
+elif printf '%s' "$INPUT" | grep -q "You are a code reviewer. Review"; then
   cat <<'EOF'
 # Final Review: NO AMENDMENTS
 

--- a/src/validate/tests_resume_backend_resolution.rs
+++ b/src/validate/tests_resume_backend_resolution.rs
@@ -649,7 +649,7 @@ elif grep -q "You are a prompt reviewer" <<< "$INPUT"; then
 ## Refined Prompt
 No changes.
 EOF
-elif grep -q "You are a final reviewer auditing a completed project for correctness, safety, and robustness." <<< "$INPUT"; then
+elif grep -q "You are a code reviewer. Review" <<< "$INPUT"; then
   cat <<'EOF'
 # Final Review: NO AMENDMENTS
 
@@ -801,7 +801,7 @@ elif grep -q "You are a project completion validator." <<< "$INPUT"; then
 The project satisfies all requirements:
 - Mock requirement: satisfied
 EOF
-elif grep -q "You are a final reviewer auditing a completed project for correctness, safety, and robustness." <<< "$INPUT"; then
+elif grep -q "You are a code reviewer. Review" <<< "$INPUT"; then
   if should_fail "final_reviewer"; then
     echo "forced final reviewer failure for resume test" >&2
     exit 1
@@ -953,7 +953,7 @@ elif grep -q "You are a project completion validator." <<< "$INPUT"; then
 The project satisfies all requirements:
 - Mock requirement: satisfied
 EOF
-elif grep -q "You are a final reviewer auditing a completed project for correctness, safety, and robustness." <<< "$INPUT"; then
+elif grep -q "You are a code reviewer. Review" <<< "$INPUT"; then
   if [ -f "$FAIL_MARKER" ]; then
     echo "forced final reviewer failure for resume test" >&2
     exit 1
@@ -1145,7 +1145,7 @@ elif grep -q "You are a prompt reviewer" <<< "$INPUT"; then
 ## Refined Prompt
 No changes.
 EOF
-elif grep -q "You are a final reviewer auditing a completed project for correctness, safety, and robustness." <<< "$INPUT"; then
+elif grep -q "You are a code reviewer. Review" <<< "$INPUT"; then
   cat <<'EOF'
 # Final Review: NO AMENDMENTS
 

--- a/src/validate/tests_stray_cleanup.rs
+++ b/src/validate/tests_stray_cleanup.rs
@@ -216,7 +216,7 @@ elif grep -q "quick-dev apply-fixes phase" <<< "$INPUT"; then
 EOF
   echo "quick-dev-fixed" >> mock_file.txt
   git add mock_file.txt
-elif grep -q "final reviewer auditing" <<< "$INPUT"; then
+elif grep -q "You are a code reviewer. Review" <<< "$INPUT"; then
   result="${QUICK_DEV_FINAL_REVIEW_RESULT:-NO_AMENDMENTS}"
   if [ "$result" = "AMENDMENTS" ]; then
     cat <<'EOF'

--- a/tests/orchestrator.rs
+++ b/tests/orchestrator.rs
@@ -2936,7 +2936,7 @@ elif [[ "$prompt" == *"You are a QA engineer validating overall project acceptan
 ## Acceptance Criteria Verification
 Project-level acceptance requirements are satisfied.
 EOF
-elif [[ "$prompt" == *"You are a final reviewer auditing a completed project for correctness, safety, and robustness."* ]]; then
+elif [[ "$prompt" == *"You are a code reviewer. Review"* ]]; then
   total=$(inc_counter "final_reviewer_total")
   inc_counter "final_reviewer_${backend_id}" >/dev/null
   round=$(( (total - 1) / 2 + 1 ))


### PR DESCRIPTION
## Summary
- Reduced final reviewer template from ~80 lines to ~30 lines
- Removed prescriptive instructions (priority levels, amendment writing guide, workflow steps, format requirements)
- Kept only: role, diff command, output format, context variables

## Motivation
Experiment comparing full vs minimal prompts against the same codebase with gpt-5.3-codex showed the minimal prompt produced more findings (2 vs 1) and better ones. The verbose instructions consumed model attention that could go toward deeper code tracing.

## Test plan
- [x] All 982 cargo tests pass
- [x] All 397 `ralph validate` conformance tests pass
- [x] `nix build` succeeds (fmt, clippy, full test suite)
- [x] Mock scripts updated to match new prompt fingerprint

🤖 Generated with [Claude Code](https://claude.com/claude-code)