### PR TITLE
fix: downgrade edit_pr failure to warning so mark_pr_ready still runs

### DIFF
--- a/src/daemon/runtime.rs
+++ b/src/daemon/runtime.rs
@@ -3251,13 +3251,10 @@ pub(crate) async fn handle_pr_flow(
         Some(url) => {
             eprintln!("editing existing PR for {task_id}: {url}");
             let body_path = body_file.path().to_path_buf();
-            match github::edit_pr(&url, &title, &body_path).await {
-                Ok(()) => {}
-                Err(err) => {
-                    return Err(RalphError::Orchestration(format!(
-                        "failed to edit PR for {task_id}: {err}"
-                    )));
-                }
+            if let Err(err) = github::edit_pr(&url, &title, &body_path).await {
+                eprintln!(
+                    "warning: failed to edit PR for {task_id} (continuing to mark-ready): {err}"
+                );
             }
 
             if let Some(pr_number) = github::extract_pr_number(&url) {


### PR DESCRIPTION
## Summary
- When `gh pr edit` fails (e.g. GitHub Projects Classic deprecation), the hard error short-circuited `handle_pr_flow` before reaching `mark_pr_ready`, leaving PRs stuck in draft state
- Changed `edit_pr` failure from `return Err(...)` to `eprintln` warning, allowing the PR to still be marked ready

## Root cause
PR #195 (task #194) stayed in draft because `gh pr edit` hit a GitHub GraphQL error (`Projects (classic) is being deprecated`). The `?` operator propagated the error before `mark_pr_ready` could run.

## Test plan
- [x] `cargo check` passes
- [x] `nix build` passes
- [x] Verified fix matches the actual daemon stderr output that showed the failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)