### PR TITLE
Update all gpt-5.3 model references to gpt-5.4

### DIFF
--- a/PLAN-qa-phase.md
+++ b/PLAN-qa-phase.md
@@ -157,7 +157,7 @@ Defaults:
 1. `qa_enabled = false`
 2. `max_qa_iterations = 3`
 3. Claude `models.qa = Some("opus")`
-4. Codex `models.qa = Some("gpt-5.3-codex-high")`
+4. Codex `models.qa = Some("gpt-5.4-high")`
 
 ### `src/config/project.rs`
 Add overrides:

--- a/PLAN.md
+++ b/PLAN.md
@@ -9,7 +9,7 @@ Ralph implements a multi-backend AI orchestration pattern where different AI sys
 Key capabilities:
 - **Plan/Implement/Review/Commit loops** with automatic backend alternation
 - **Per-role model selection** — different models for different roles (e.g., opus for planning, sonnet for reformatting)
-- **Codex reasoning effort decomposition** — suffixed model names (e.g., `gpt-5.3-codex-xhigh`) are automatically split into base model + effort CLI flag
+- **Codex reasoning effort decomposition** — suffixed model names (e.g., `gpt-5.4-xhigh`) are automatically split into base model + effort CLI flag
 - **Parse retry with reformatter agent** — failed output parsing triggers a reformatter (opposite backend) before full retry
 - **Auto-rollback** on review iteration limit exceeded
 - **Tmux execution mode** — visual backend execution in tmux windows with labeled panes
@@ -105,7 +105,7 @@ Backend references use the format `"backend"` or `"backend(model)"`:
 claude              # Claude with default model
 claude(opus)        # Claude with explicit model
 codex               # Codex with default model
-codex(gpt-5.3-codex-xhigh)  # Codex with suffixed model
+codex(gpt-5.4-xhigh)  # Codex with suffixed model
 ```
 
 The `parse_backend_spec()` function in `src/backend/mod.rs` parses these into `BackendSpec { name, model }`.
@@ -115,9 +115,9 @@ The `parse_backend_spec()` function in `src/backend/mod.rs` parses these into `B
 Codex model names with known effort suffixes (`-xhigh`, `-high`, `-medium`, `-low`) are automatically decomposed at invocation time:
 
 ```
-Config model: gpt-5.3-codex-xhigh
-CLI args:     codex -c model_reasoning_effort="xhigh" --model gpt-5.3-codex exec ...
-Display name: codex(gpt-5.3-codex-xhigh)  (preserved for state.json/logs)
+Config model: gpt-5.4-xhigh
+CLI args:     codex -c model_reasoning_effort="xhigh" --model gpt-5.4 exec ...
+Display name: codex(gpt-5.4-xhigh)  (preserved for state.json/logs)
 ```
 
 Suffix matching is longest-first (`-xhigh` before `-high`). Unknown suffixes pass through unchanged. This is codex-specific — Claude model names are not decomposed.
@@ -143,12 +143,12 @@ Code defaults (in `GlobalConfig::default()`):
 
 | Role | Claude | Codex |
 |------|--------|-------|
-| planner | opus | gpt-5.3-codex-xhigh |
-| implementer | opus | gpt-5.3-codex-high |
-| reviewer | opus | gpt-5.3-codex-xhigh |
-| qa | opus | gpt-5.3-codex-high |
-| completer | opus | gpt-5.3-codex-xhigh |
-| reformatter | sonnet | gpt-5.3-codex-medium |
+| planner | opus | gpt-5.4-xhigh |
+| implementer | opus | gpt-5.4-high |
+| reviewer | opus | gpt-5.4-xhigh |
+| qa | opus | gpt-5.4-high |
+| completer | opus | gpt-5.4-xhigh |
+| reformatter | sonnet | gpt-5.4-medium |
 
 When `GlobalConfig::load()` reads `ralph.toml`, any omitted model fields are filled from code defaults via `BackendRoleModels::fill_from()`. This means `ralph.toml` only needs to specify model overrides — omitted fields get the code defaults automatically.
 
@@ -276,7 +276,7 @@ When a backend response cannot be parsed (missing H1, wrong format):
 3. **Attempt 3 (reminded original)**: If reformatter output also fails, retry with the **original backend** using the original prompt augmented with a format reminder preamble
 4. If still failing, fail with `ParseRetriesExhausted`
 
-The reformatter role uses a lighter model (e.g., `sonnet` for Claude, `gpt-5.3-codex-medium` for Codex) since it only needs to reformat, not generate.
+The reformatter role uses a lighter model (e.g., `sonnet` for Claude, `gpt-5.4-medium` for Codex) since it only needs to reformat, not generate.
 
 ### Auto-Rollback on Review Iteration Limit
 
@@ -355,7 +355,7 @@ The orchestrator injects YAML frontmatter; backend responses provide body conten
 artifact: impl-notes
 loop: 3
 project: my-project
-backend: codex(gpt-5.3-codex-high)
+backend: codex(gpt-5.4-high)
 role: implementer
 created_at: 2026-02-05T14:30:00Z
 ---
@@ -451,12 +451,12 @@ timeout_seconds = 600
 env = {}
 
 [backends.codex.models]         # Optional — code defaults apply for omitted fields
-planner = "gpt-5.3-codex-xhigh"
-implementer = "gpt-5.3-codex-high"
-reviewer = "gpt-5.3-codex-xhigh"
-qa = "gpt-5.3-codex-high"
-completer = "gpt-5.3-codex-xhigh"
-reformatter = "gpt-5.3-codex-medium"
+planner = "gpt-5.4-xhigh"
+implementer = "gpt-5.4-high"
+reviewer = "gpt-5.4-xhigh"
+qa = "gpt-5.4-high"
+completer = "gpt-5.4-xhigh"
+reformatter = "gpt-5.4-medium"
 
 [workflow]
 max_review_iterations = 30
@@ -469,9 +469,9 @@ max_qa_iterations = 3                   # Maximum QA retry attempts before rollb
 # qa_backend = "claude(opus)"           # Override QA backend (default: planner-aligned)
 # Per-role backend overrides (optional):
 # planner_backend = "claude(opus)"
-# implementer_backend = "codex(gpt-5.3-codex-high)"
+# implementer_backend = "codex(gpt-5.4-high)"
 # reviewer_backend = "claude(opus)"
-# completer_backend = "codex(gpt-5.3-codex-xhigh)"
+# completer_backend = "codex(gpt-5.4-xhigh)"
 
 [templates]
 planner = "templates/spec.md"

--- a/PROMPT-codex-reasoning-effort.md
+++ b/PROMPT-codex-reasoning-effort.md
@@ -2,13 +2,13 @@
 
 ## Overview
 
-The codex CLI `model_reasoning_effort` config controls how much reasoning the model applies. Ralph's per-role model config already encodes effort in the model name suffix (e.g., `gpt-5.3-codex-xhigh`, `gpt-5.3-codex-high`, `gpt-5.3-codex-medium`). However, ChatGPT accounts don't support these suffixed model names — only the base `gpt-5.3-codex` works. The effort must be passed separately via `-c model_reasoning_effort="xhigh"`.
+The codex CLI `model_reasoning_effort` config controls how much reasoning the model applies. Ralph's per-role model config already encodes effort in the model name suffix (e.g., `gpt-5.4-xhigh`, `gpt-5.4-high`, `gpt-5.4-medium`). However, ChatGPT accounts don't support these suffixed model names — only the base `gpt-5.4` works. The effort must be passed separately via `-c model_reasoning_effort="xhigh"`.
 
-This feature makes ralph **decompose** suffixed codex model names at invocation time: strip the known effort suffix from the model name and pass it as a separate `-c model_reasoning_effort="..."` CLI arg. This way the existing config (`models.planner = "gpt-5.3-codex-xhigh"`) keeps working unchanged — ralph just interprets the suffix intelligently.
+This feature makes ralph **decompose** suffixed codex model names at invocation time: strip the known effort suffix from the model name and pass it as a separate `-c model_reasoning_effort="..."` CLI arg. This way the existing config (`models.planner = "gpt-5.4-xhigh"`) keeps working unchanged — ralph just interprets the suffix intelligently.
 
 ## Background
 
-The codex CLI accepts: `codex exec -c model_reasoning_effort="xhigh" --model gpt-5.3-codex ...`
+The codex CLI accepts: `codex exec -c model_reasoning_effort="xhigh" --model gpt-5.4 ...`
 
 Known effort suffixes: `-low`, `-medium`, `-high`, `-xhigh`. These are appended to a base codex model name.
 
@@ -77,8 +77,8 @@ pub fn backend_from_config(config: &GlobalConfig, model: Option<&str>) -> CliBac
 ```
 
 Key points:
-- The **display name** keeps the original suffixed model (e.g., `codex(gpt-5.3-codex-xhigh)`) so state.json and logs show exactly what was configured.
-- The **CLI args** use the base model name (`--model gpt-5.3-codex`) plus the extracted effort (`-c model_reasoning_effort="xhigh"`).
+- The **display name** keeps the original suffixed model (e.g., `codex(gpt-5.4-xhigh)`) so state.json and logs show exactly what was configured.
+- The **CLI args** use the base model name (`--model gpt-5.4`) plus the extracted effort (`-c model_reasoning_effort="xhigh"`).
 - If the model has no known suffix, no `-c model_reasoning_effort` arg is injected (the codex CLI will use its own config default).
 - The `claude.rs` `backend_from_config()` is NOT modified — suffix decomposition is codex-specific.
 
@@ -87,7 +87,7 @@ Key points:
 - **No new config structs** — no `BackendRoleReasoningEfforts`. The existing `BackendRoleModels` with suffixed model names is the configuration mechanism.
 - **No changes to `BackendConfig`** — the models config stays as-is.
 - **No changes to `BackendRegistry`**, `resolve_backend_for_role()`, `get_or_create_for_spec()`, or the orchestrator — all the decomposition happens inside `codex::backend_from_config()`.
-- **No changes to default model names** — `gpt-5.3-codex-xhigh`, `gpt-5.3-codex-high`, `gpt-5.3-codex-medium` stay as defaults.
+- **No changes to default model names** — `gpt-5.4-xhigh`, `gpt-5.4-high`, `gpt-5.4-medium` stay as defaults.
 - **No changes to `parse_backend_spec()`** — the spec format is unchanged.
 - **No changes to `ralph.toml` live config** — user file, not touched.
 
@@ -105,59 +105,59 @@ Key points:
 
 #[test]
 fn parse_codex_model_effort_strips_xhigh() {
-    let (base, effort) = parse_codex_model_effort("gpt-5.3-codex-xhigh");
-    assert_eq!(base, "gpt-5.3-codex");
+    let (base, effort) = parse_codex_model_effort("gpt-5.4-xhigh");
+    assert_eq!(base, "gpt-5.4");
     assert_eq!(effort, Some("xhigh"));
 }
 
 #[test]
 fn parse_codex_model_effort_strips_high() {
-    let (base, effort) = parse_codex_model_effort("gpt-5.3-codex-high");
-    assert_eq!(base, "gpt-5.3-codex");
+    let (base, effort) = parse_codex_model_effort("gpt-5.4-high");
+    assert_eq!(base, "gpt-5.4");
     assert_eq!(effort, Some("high"));
 }
 
 #[test]
 fn parse_codex_model_effort_strips_medium() {
-    let (base, effort) = parse_codex_model_effort("gpt-5.3-codex-medium");
-    assert_eq!(base, "gpt-5.3-codex");
+    let (base, effort) = parse_codex_model_effort("gpt-5.4-medium");
+    assert_eq!(base, "gpt-5.4");
     assert_eq!(effort, Some("medium"));
 }
 
 #[test]
 fn parse_codex_model_effort_strips_low() {
-    let (base, effort) = parse_codex_model_effort("gpt-5.3-codex-low");
-    assert_eq!(base, "gpt-5.3-codex");
+    let (base, effort) = parse_codex_model_effort("gpt-5.4-low");
+    assert_eq!(base, "gpt-5.4");
     assert_eq!(effort, Some("low"));
 }
 
 #[test]
 fn parse_codex_model_effort_no_suffix() {
-    let (base, effort) = parse_codex_model_effort("gpt-5.3-codex");
-    assert_eq!(base, "gpt-5.3-codex");
+    let (base, effort) = parse_codex_model_effort("gpt-5.4");
+    assert_eq!(base, "gpt-5.4");
     assert_eq!(effort, None);
 }
 
 #[test]
 fn parse_codex_model_effort_unknown_suffix() {
-    let (base, effort) = parse_codex_model_effort("gpt-5.3-codex-turbo");
-    assert_eq!(base, "gpt-5.3-codex-turbo");
+    let (base, effort) = parse_codex_model_effort("gpt-5.4-turbo");
+    assert_eq!(base, "gpt-5.4-turbo");
     assert_eq!(effort, None);
 }
 ```
 
-Integration test in `tests/backend.rs`: Create a codex backend with a suffixed model via `get_or_create_for_spec("codex(gpt-5.3-codex-xhigh)")`, execute it against a mock script that prints its args, and verify the output contains `--model gpt-5.3-codex` and `-c model_reasoning_effort="xhigh"` (not `--model gpt-5.3-codex-xhigh`).
+Integration test in `tests/backend.rs`: Create a codex backend with a suffixed model via `get_or_create_for_spec("codex(gpt-5.4-xhigh)")`, execute it against a mock script that prints its args, and verify the output contains `--model gpt-5.4` and `-c model_reasoning_effort="xhigh"` (not `--model gpt-5.4-xhigh`).
 
 ## Verification
 
-`nix build` passes. A codex backend configured with model `gpt-5.3-codex-xhigh` should produce:
+`nix build` passes. A codex backend configured with model `gpt-5.4-xhigh` should produce:
 ```
-codex -c model_reasoning_effort="xhigh" --model gpt-5.3-codex exec --dangerously-bypass-approvals-and-sandbox -
+codex -c model_reasoning_effort="xhigh" --model gpt-5.4 exec --dangerously-bypass-approvals-and-sandbox -
 ```
 
-A codex backend with model `gpt-5.3-codex` (no suffix) should produce:
+A codex backend with model `gpt-5.4` (no suffix) should produce:
 ```
-codex --model gpt-5.3-codex exec --dangerously-bypass-approvals-and-sandbox -
+codex --model gpt-5.4 exec --dangerously-bypass-approvals-and-sandbox -
 ```
 
 ## Scope Boundaries

--- a/PROMPT-explicit-models.md
+++ b/PROMPT-explicit-models.md
@@ -2,13 +2,13 @@
 
 ## Goal
 
-Allow users to specify which model each backend should use, using the syntax `backend(model)` — e.g. `claude(opus)`, `codex(gpt-5.3-codex-xhigh)`. This applies everywhere a backend name is accepted: `default_backend`, `starting_backend`, and `--backend` CLI flag.
+Allow users to specify which model each backend should use, using the syntax `backend(model)` — e.g. `claude(opus)`, `codex(gpt-5.4-xhigh)`. This applies everywhere a backend name is accepted: `default_backend`, `starting_backend`, and `--backend` CLI flag.
 
 ## Current State
 
 Backend names are bare strings like `"claude"` or `"codex"`. The backend config in `ralph.toml` defines the command and args but has no model concept. The CLI backends both accept a `--model <MODEL>` flag:
 - `claude --model opus` or `claude --model claude-opus-4-6`
-- `codex exec --model gpt-5.3-codex-xhigh ...`
+- `codex exec --model gpt-5.4-xhigh ...`
 
 ## Design
 
@@ -17,7 +17,7 @@ Backend names are bare strings like `"claude"` or `"codex"`. The backend config 
 When a backend reference includes parentheses, parse it as `name(model)`:
 - `claude` → backend="claude", model=None (use whatever default the CLI uses)
 - `claude(opus)` → backend="claude", model=Some("opus")
-- `codex(gpt-5.3-codex-xhigh)` → backend="codex", model=Some("gpt-5.3-codex-xhigh")
+- `codex(gpt-5.4-xhigh)` → backend="codex", model=Some("gpt-5.4-xhigh")
 
 ### Where model specs appear
 

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ Examples:
 - `codex`
 - `openrouter`
 - `claude(opus)`
-- `codex(gpt-5.3-codex-xhigh)`
-- `openrouter(openai/gpt-5.3-codex)`
+- `codex(gpt-5.4-xhigh)`
+- `openrouter(openai/gpt-5.4)`
 
 The `openrouter` backend routes model requests through the [OpenRouter](https://openrouter.ai/) API (a model-routing API) and uses [Goose](https://github.com/block/goose) as its CLI runner. It provides access to models from multiple providers (for example OpenAI, Anthropic, and Google) through one backend. This backend is disabled by default (`enabled = false`) and requires an OpenRouter API key.
 
@@ -118,7 +118,7 @@ Examples:
 ./result/bin/ralph config show
 ./result/bin/ralph config get workflow.qa_enabled
 ./result/bin/ralph config set workflow.qa_enabled false
-./result/bin/ralph config set workflow.planner_backend codex(gpt-5.3-codex-high) --project demo
+./result/bin/ralph config set workflow.planner_backend codex(gpt-5.4-high) --project demo
 ```
 
 ## Validate Conformance Tests

--- a/src/backend/codex.rs
+++ b/src/backend/codex.rs
@@ -70,43 +70,43 @@ mod tests {
 
     #[test]
     fn parse_codex_model_effort_strips_xhigh() {
-        let (base, effort) = parse_codex_model_effort("gpt-5.3-codex-xhigh");
-        assert_eq!(base, "gpt-5.3-codex");
+        let (base, effort) = parse_codex_model_effort("gpt-5.4-xhigh");
+        assert_eq!(base, "gpt-5.4");
         assert_eq!(effort, Some("xhigh"));
     }
 
     #[test]
     fn parse_codex_model_effort_strips_high() {
-        let (base, effort) = parse_codex_model_effort("gpt-5.3-codex-high");
-        assert_eq!(base, "gpt-5.3-codex");
+        let (base, effort) = parse_codex_model_effort("gpt-5.4-high");
+        assert_eq!(base, "gpt-5.4");
         assert_eq!(effort, Some("high"));
     }
 
     #[test]
     fn parse_codex_model_effort_strips_medium() {
-        let (base, effort) = parse_codex_model_effort("gpt-5.3-codex-medium");
-        assert_eq!(base, "gpt-5.3-codex");
+        let (base, effort) = parse_codex_model_effort("gpt-5.4-medium");
+        assert_eq!(base, "gpt-5.4");
         assert_eq!(effort, Some("medium"));
     }
 
     #[test]
     fn parse_codex_model_effort_strips_low() {
-        let (base, effort) = parse_codex_model_effort("gpt-5.3-codex-low");
-        assert_eq!(base, "gpt-5.3-codex");
+        let (base, effort) = parse_codex_model_effort("gpt-5.4-low");
+        assert_eq!(base, "gpt-5.4");
         assert_eq!(effort, Some("low"));
     }
 
     #[test]
     fn parse_codex_model_effort_no_suffix() {
-        let (base, effort) = parse_codex_model_effort("gpt-5.3-codex");
-        assert_eq!(base, "gpt-5.3-codex");
+        let (base, effort) = parse_codex_model_effort("gpt-5.4");
+        assert_eq!(base, "gpt-5.4");
         assert_eq!(effort, None);
     }
 
     #[test]
     fn parse_codex_model_effort_unknown_suffix() {
-        let (base, effort) = parse_codex_model_effort("gpt-5.3-codex-turbo");
-        assert_eq!(base, "gpt-5.3-codex-turbo");
+        let (base, effort) = parse_codex_model_effort("gpt-5.4-turbo");
+        assert_eq!(base, "gpt-5.4-turbo");
         assert_eq!(effort, None);
     }
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1569,14 +1569,14 @@ mod tests {
 
     #[test]
     fn parse_backend_spec_accepts_optional_name_with_model() {
-        let parsed = parse_backend_spec("?openrouter(gpt-5.3-codex-xhigh)")
-            .expect("optional modeled backend");
+        let parsed =
+            parse_backend_spec("?openrouter(gpt-5.4-xhigh)").expect("optional modeled backend");
         assert_eq!(
             parsed,
             BackendSpec {
                 optional: true,
                 name: "openrouter".to_owned(),
-                model: Some("gpt-5.3-codex-xhigh".to_owned()),
+                model: Some("gpt-5.4-xhigh".to_owned()),
             }
         );
     }
@@ -1656,9 +1656,9 @@ mod tests {
         let mut registry = BackendRegistry::new(&config, tmux_disabled());
 
         let backend = registry
-            .get_or_create_for_spec("openrouter(gpt-5.3-codex-xhigh)")
+            .get_or_create_for_spec("openrouter(gpt-5.4-xhigh)")
             .expect("openrouter backend should be creatable from registry");
-        assert_eq!(backend.name(), "openrouter(gpt-5.3-codex-xhigh)");
+        assert_eq!(backend.name(), "openrouter(gpt-5.4-xhigh)");
     }
 
     #[test]
@@ -2088,7 +2088,7 @@ sleep 30
                 "exec".to_owned(),
                 "--dangerously-bypass-approvals-and-sandbox".to_owned(),
                 "--model".to_owned(),
-                "gpt-5.3".to_owned(),
+                "gpt-5.4".to_owned(),
                 "-".to_owned(),
             ],
             Duration::from_secs(10),
@@ -2124,7 +2124,7 @@ sleep 30
         // Original flags preserved
         assert!(args.contains(&"--dangerously-bypass-approvals-and-sandbox".to_owned()));
         assert!(args.contains(&"--model".to_owned()));
-        assert!(args.contains(&"gpt-5.3".to_owned()));
+        assert!(args.contains(&"gpt-5.4".to_owned()));
     }
 
     #[test]
@@ -2423,7 +2423,7 @@ done
         config.backends.openrouter.enabled = BackendEnabled::Disabled;
         let registry = BackendRegistry::new(&config, tmux_disabled());
         assert!(!registry.is_backend_available("openrouter"));
-        assert!(!registry.is_backend_available("openrouter(gpt-5.3-codex-xhigh)"));
+        assert!(!registry.is_backend_available("openrouter(gpt-5.4-xhigh)"));
     }
 
     #[test]

--- a/src/cli/backend_spec.rs
+++ b/src/cli/backend_spec.rs
@@ -58,7 +58,7 @@ mod tests {
     #[test]
     fn validate_codex_with_model() {
         let config = GlobalConfig::default();
-        validate_backend_spec("codex(gpt-5.3-codex-xhigh)", &config)
+        validate_backend_spec("codex(gpt-5.4-xhigh)", &config)
             .expect("codex with model should be valid");
     }
 
@@ -126,7 +126,7 @@ mod tests {
 
     #[test]
     fn validate_name_only_accepts_optional_openrouter_with_model() {
-        validate_backend_spec_name("?openrouter(gpt-5.3-codex-xhigh)")
+        validate_backend_spec_name("?openrouter(gpt-5.4-xhigh)")
             .expect("optional openrouter with model should be valid");
     }
 }

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -884,7 +884,7 @@ mod tests {
 
     #[test]
     fn ensure_backend_accepts_codex_with_model() {
-        ensure_backend("codex(gpt-5.3-codex-xhigh)").expect("codex with model should pass");
+        ensure_backend("codex(gpt-5.4-xhigh)").expect("codex with model should pass");
     }
 
     #[test]
@@ -937,9 +937,9 @@ mod tests {
 
     #[test]
     fn parse_optional_backend_accepts_optional_openrouter() {
-        let result = parse_optional_backend("?openrouter(gpt-5.3-codex-xhigh)")
+        let result = parse_optional_backend("?openrouter(gpt-5.4-xhigh)")
             .expect("optional openrouter should parse successfully");
-        assert_eq!(result, Some("?openrouter(gpt-5.3-codex-xhigh)".to_owned()));
+        assert_eq!(result, Some("?openrouter(gpt-5.4-xhigh)".to_owned()));
     }
 
     #[test]
@@ -964,7 +964,7 @@ mod tests {
         let err = set_global_value(
             &mut config,
             "workflow.prompt_review_backend",
-            "?openrouter(gpt-5.3-codex-xhigh)",
+            "?openrouter(gpt-5.4-xhigh)",
         )
         .expect_err("optional syntax should be rejected for singular alias");
         assert!(err.to_string().contains(

--- a/src/cli/project.rs
+++ b/src/cli/project.rs
@@ -226,8 +226,7 @@ mod tests {
 
     #[test]
     fn project_backend_accepts_codex_with_model() {
-        validate_backend_spec_name("codex(gpt-5.3-codex-xhigh)")
-            .expect("codex with model should pass");
+        validate_backend_spec_name("codex(gpt-5.4-xhigh)").expect("codex with model should pass");
     }
 
     #[test]

--- a/src/config/global.rs
+++ b/src/config/global.rs
@@ -785,15 +785,15 @@ fn default_codex_backend_config() -> BackendConfig {
         enabled: BackendEnabled::Auto,
         env: BTreeMap::new(),
         models: BackendRoleModels {
-            planner: Some("gpt-5.3-codex-xhigh".to_owned()),
-            implementer: Some("gpt-5.3-codex-high".to_owned()),
-            reviewer: Some("gpt-5.3-codex-high".to_owned()),
-            final_reviewer: Some("gpt-5.3-codex-high".to_owned()),
-            arbiter: Some("gpt-5.3-codex-xhigh".to_owned()),
-            qa: Some("gpt-5.3-codex-high".to_owned()),
-            completer: Some("gpt-5.3-codex-xhigh".to_owned()),
-            acceptance_qa: Some("gpt-5.3-codex-xhigh".to_owned()),
-            reformatter: Some("gpt-5.3-codex-medium".to_owned()),
+            planner: Some("gpt-5.4-xhigh".to_owned()),
+            implementer: Some("gpt-5.4-high".to_owned()),
+            reviewer: Some("gpt-5.4-high".to_owned()),
+            final_reviewer: Some("gpt-5.4-high".to_owned()),
+            arbiter: Some("gpt-5.4-xhigh".to_owned()),
+            qa: Some("gpt-5.4-high".to_owned()),
+            completer: Some("gpt-5.4-xhigh".to_owned()),
+            acceptance_qa: Some("gpt-5.4-xhigh".to_owned()),
+            reformatter: Some("gpt-5.4-medium".to_owned()),
         },
         role_timeouts: RoleTimeouts::default(),
     }
@@ -1043,7 +1043,7 @@ fn default_prompt_review_enabled() -> bool {
 }
 
 fn default_prompt_review_backend() -> String {
-    "codex(gpt-5.3-codex-xhigh)".to_owned()
+    "codex(gpt-5.4-xhigh)".to_owned()
 }
 
 fn default_prompt_review_min_reviewers() -> u32 {
@@ -2061,12 +2061,12 @@ command = "claude-custom"
         assert!(config.workflow.prompt_review_enabled);
         assert_eq!(
             config.workflow.prompt_review_backend,
-            "codex(gpt-5.3-codex-xhigh)"
+            "codex(gpt-5.4-xhigh)"
         );
         assert!(config.workflow.prompt_review_backends.is_none());
         assert_eq!(
             config.workflow.prompt_review_backends_or_default(),
-            vec!["codex(gpt-5.3-codex-xhigh)".to_owned()]
+            vec!["codex(gpt-5.4-xhigh)".to_owned()]
         );
         assert_eq!(config.workflow.prompt_review_min_reviewers, 1);
         assert_eq!(
@@ -2076,8 +2076,8 @@ command = "claude-custom"
         );
         assert_eq!(
             config.backends.codex.models.qa.as_deref(),
-            Some("gpt-5.3-codex-high"),
-            "codex qa model should default to gpt-5.3-codex-high"
+            Some("gpt-5.4-high"),
+            "codex qa model should default to gpt-5.4-high"
         );
         assert_eq!(config.templates.qa, "templates/qa.md");
         assert_eq!(
@@ -2308,12 +2308,12 @@ base_branch = "master"
         assert!(config.workflow.prompt_review_enabled);
         assert_eq!(
             config.workflow.prompt_review_backend,
-            "codex(gpt-5.3-codex-xhigh)"
+            "codex(gpt-5.4-xhigh)"
         );
         assert!(config.workflow.prompt_review_backends.is_none());
         assert_eq!(
             config.workflow.prompt_review_backends_or_default(),
-            vec!["codex(gpt-5.3-codex-xhigh)".to_owned()]
+            vec!["codex(gpt-5.4-xhigh)".to_owned()]
         );
         assert_eq!(config.workflow.prompt_review_min_reviewers, 1);
         assert_eq!(config.templates.qa, "templates/qa.md");
@@ -2377,16 +2377,16 @@ daemon_max_concurrent = 2
 daemon_labels = ["ralph:ready", "triage"]
 daemon_repo = "acme/widgets"
 daemon_refinement_enabled = false
-daemon_refinement_backend = "codex(gpt-5.3-codex-medium)"
+daemon_refinement_backend = "codex(gpt-5.4-medium)"
 daemon_auto_rebase_enabled = false
 daemon_rebase_interval_seconds = 900
 daemon_max_rebases_per_cycle = 5
 daemon_rebase_timeout_seconds = 240
 daemon_rebase_agent_backend = "none"
 daemon_prd_enabled = false
-daemon_prd_question_backends = ["claude(opus)", "codex(gpt-5.3-codex-high)"]
+daemon_prd_question_backends = ["claude(opus)", "codex(gpt-5.4-high)"]
 daemon_prd_writer_backend = "claude(sonnet)"
-daemon_prd_reviewer_backend = "codex(gpt-5.3-codex-medium)"
+daemon_prd_reviewer_backend = "codex(gpt-5.4-medium)"
 daemon_prd_max_revisions = 7
 daemon_prd_backend_timeout_secs = 300
 
@@ -2437,7 +2437,7 @@ base_branch = "master"
         assert!(!config.workspace.daemon_refinement_enabled);
         assert_eq!(
             config.workspace.daemon_refinement_backend,
-            "codex(gpt-5.3-codex-medium)"
+            "codex(gpt-5.4-medium)"
         );
         assert!(!config.workspace.daemon_auto_rebase_enabled);
         assert_eq!(config.workspace.daemon_rebase_interval_seconds, 900);
@@ -2447,15 +2447,12 @@ base_branch = "master"
         assert!(!config.workspace.daemon_prd_enabled);
         assert_eq!(
             config.workspace.daemon_prd_question_backends,
-            vec![
-                "claude(opus)".to_owned(),
-                "codex(gpt-5.3-codex-high)".to_owned()
-            ]
+            vec!["claude(opus)".to_owned(), "codex(gpt-5.4-high)".to_owned()]
         );
         assert_eq!(config.workspace.daemon_prd_writer_backend, "claude(sonnet)");
         assert_eq!(
             config.workspace.daemon_prd_reviewer_backend,
-            "codex(gpt-5.3-codex-medium)"
+            "codex(gpt-5.4-medium)"
         );
         assert_eq!(config.workspace.daemon_prd_max_revisions, 7);
         assert_eq!(config.workspace.daemon_prd_backend_timeout_secs, 300);
@@ -2547,15 +2544,15 @@ command = "codex"
 timeout_seconds = 7200
 
 [backends.codex.models]
-planner = "gpt-5.3-codex-xhigh"
-implementer = "gpt-5.3-codex-high"
-reviewer = "gpt-5.3-codex-high"
-final_reviewer = "gpt-5.3-codex-high"
-arbiter = "gpt-5.3-codex-xhigh"
-qa = "gpt-5.3-codex-high"
-completer = "gpt-5.3-codex-xhigh"
-acceptance_qa = "gpt-5.3-codex-xhigh"
-reformatter = "gpt-5.3-codex-medium"
+planner = "gpt-5.4-xhigh"
+implementer = "gpt-5.4-high"
+reviewer = "gpt-5.4-high"
+final_reviewer = "gpt-5.4-high"
+arbiter = "gpt-5.4-xhigh"
+qa = "gpt-5.4-high"
+completer = "gpt-5.4-xhigh"
+acceptance_qa = "gpt-5.4-xhigh"
+reformatter = "gpt-5.4-medium"
 
 [workflow]
 max_review_iterations = 5
@@ -2613,39 +2610,39 @@ base_branch = "master"
         );
         assert_eq!(
             config.backends.codex.models.planner.as_deref(),
-            Some("gpt-5.3-codex-xhigh")
+            Some("gpt-5.4-xhigh")
         );
         assert_eq!(
             config.backends.codex.models.implementer.as_deref(),
-            Some("gpt-5.3-codex-high")
+            Some("gpt-5.4-high")
         );
         assert_eq!(
             config.backends.codex.models.reviewer.as_deref(),
-            Some("gpt-5.3-codex-high")
+            Some("gpt-5.4-high")
         );
         assert_eq!(
             config.backends.codex.models.final_reviewer.as_deref(),
-            Some("gpt-5.3-codex-high")
+            Some("gpt-5.4-high")
         );
         assert_eq!(
             config.backends.codex.models.arbiter.as_deref(),
-            Some("gpt-5.3-codex-xhigh")
+            Some("gpt-5.4-xhigh")
         );
         assert_eq!(
             config.backends.codex.models.qa.as_deref(),
-            Some("gpt-5.3-codex-high")
+            Some("gpt-5.4-high")
         );
         assert_eq!(
             config.backends.codex.models.completer.as_deref(),
-            Some("gpt-5.3-codex-xhigh")
+            Some("gpt-5.4-xhigh")
         );
         assert_eq!(
             config.backends.codex.models.acceptance_qa.as_deref(),
-            Some("gpt-5.3-codex-xhigh")
+            Some("gpt-5.4-xhigh")
         );
         assert_eq!(
             config.backends.codex.models.reformatter.as_deref(),
-            Some("gpt-5.3-codex-medium")
+            Some("gpt-5.4-medium")
         );
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1046,7 +1046,7 @@ mod tests {
             global,
             Some(project),
             RunWorkflowOverrides {
-                planner_backend: Some("codex(gpt-5.3-codex)"),
+                planner_backend: Some("codex(gpt-5.4)"),
                 implementer_backend: Some("claude(opus)"),
                 ..RunWorkflowOverrides::default()
             },
@@ -1055,7 +1055,7 @@ mod tests {
 
         assert_eq!(
             effective.workflow.planner_backend.as_deref(),
-            Some("codex(gpt-5.3-codex)")
+            Some("codex(gpt-5.4)")
         );
         assert_eq!(
             effective.workflow.implementer_backend.as_deref(),
@@ -1097,9 +1097,8 @@ mod tests {
         global.workflow.qa_enabled = false;
         global.workflow.max_qa_iterations = 3;
         global.workflow.prompt_review_enabled = true;
-        global.workflow.prompt_review_backend = "codex(gpt-5.3-codex-xhigh)".to_owned();
-        global.workflow.prompt_review_backends =
-            Some(vec!["codex(gpt-5.3-codex-xhigh)".to_owned()]);
+        global.workflow.prompt_review_backend = "codex(gpt-5.4-xhigh)".to_owned();
+        global.workflow.prompt_review_backends = Some(vec!["codex(gpt-5.4-xhigh)".to_owned()]);
         global.templates.qa = "templates/qa-global.md".to_owned();
         global.templates.prompt_reviewer = "templates/prompt-reviewer-global.md".to_owned();
         global.templates.prompt_review_validator =
@@ -1235,10 +1234,8 @@ mod tests {
     #[test]
     fn validate_prd_config_rejects_invalid_backend_specs() {
         let mut global = GlobalConfig::default();
-        global.workspace.daemon_prd_question_backends = vec![
-            "claude(opus)".to_owned(),
-            "codex(gpt-5.3-codex-high)".to_owned(),
-        ];
+        global.workspace.daemon_prd_question_backends =
+            vec!["claude(opus)".to_owned(), "codex(gpt-5.4-high)".to_owned()];
         global.workspace.daemon_prd_writer_backend = "unknown(model)".to_owned();
 
         let error = validate_interactive_prd_workspace_config(&global)
@@ -1316,10 +1313,8 @@ mod tests {
         global.workspace.daemon_rebase_timeout_seconds = 120;
         global.workspace.daemon_rebase_agent_backend = "claude(opus)".to_owned();
         global.workspace.daemon_prd_enabled = true;
-        global.workspace.daemon_prd_question_backends = vec![
-            "claude(opus)".to_owned(),
-            "codex(gpt-5.3-codex-high)".to_owned(),
-        ];
+        global.workspace.daemon_prd_question_backends =
+            vec!["claude(opus)".to_owned(), "codex(gpt-5.4-high)".to_owned()];
         global.workspace.daemon_prd_writer_backend = "claude".to_owned();
         global.workspace.daemon_prd_reviewer_backend = "codex".to_owned();
         global.workspace.daemon_prd_max_revisions = 3;
@@ -1332,7 +1327,7 @@ mod tests {
                 labels: Some(vec!["l1".to_owned(), "l2".to_owned()]),
                 repo: Some("acme/project".to_owned()),
                 refinement_enabled: Some(false),
-                refinement_backend: Some("codex(gpt-5.3-codex-medium)".to_owned()),
+                refinement_backend: Some("codex(gpt-5.4-medium)".to_owned()),
                 auto_rebase_enabled: Some(false),
                 rebase_interval_seconds: Some(900),
                 max_rebases_per_cycle: Some(5),
@@ -1348,7 +1343,7 @@ mod tests {
         assert_eq!(effective.labels, vec!["l1".to_owned(), "l2".to_owned()]);
         assert_eq!(effective.repo.as_deref(), Some("acme/project"));
         assert!(!effective.refinement_enabled);
-        assert_eq!(effective.refinement_backend, "codex(gpt-5.3-codex-medium)");
+        assert_eq!(effective.refinement_backend, "codex(gpt-5.4-medium)");
         assert!(!effective.auto_rebase_enabled);
         assert_eq!(effective.rebase_interval_seconds, 900);
         assert_eq!(effective.max_rebases_per_cycle, 5);
@@ -1357,10 +1352,7 @@ mod tests {
         assert!(effective.prd_enabled);
         assert_eq!(
             effective.prd_question_backends,
-            vec![
-                "claude(opus)".to_owned(),
-                "codex(gpt-5.3-codex-high)".to_owned()
-            ]
+            vec!["claude(opus)".to_owned(), "codex(gpt-5.4-high)".to_owned()]
         );
         assert_eq!(effective.prd_writer_backend, "claude");
         assert_eq!(effective.prd_reviewer_backend, "codex");
@@ -1383,10 +1375,7 @@ mod tests {
         assert!(no_project.prd_enabled);
         assert_eq!(
             no_project.prd_question_backends,
-            vec![
-                "claude(opus)".to_owned(),
-                "codex(gpt-5.3-codex-high)".to_owned()
-            ]
+            vec!["claude(opus)".to_owned(), "codex(gpt-5.4-high)".to_owned()]
         );
         assert_eq!(no_project.prd_writer_backend, "claude");
         assert_eq!(no_project.prd_reviewer_backend, "codex");
@@ -1881,8 +1870,7 @@ mod tests {
     fn prompt_review_alias_explicit_global_plural_wins_even_when_equal_to_default() {
         let mut global = GlobalConfig::default();
         global.workflow.prompt_review_backend = "claude(opus)".to_owned();
-        global.workflow.prompt_review_backends =
-            Some(vec!["codex(gpt-5.3-codex-xhigh)".to_owned()]);
+        global.workflow.prompt_review_backends = Some(vec!["codex(gpt-5.4-xhigh)".to_owned()]);
 
         let effective = resolve_effective_config(
             Path::new("/workspace"),
@@ -1895,7 +1883,7 @@ mod tests {
 
         assert_eq!(
             effective.workflow.prompt_review_backends,
-            vec!["codex(gpt-5.3-codex-xhigh)".to_owned()]
+            vec!["codex(gpt-5.4-xhigh)".to_owned()]
         );
     }
 
@@ -1904,7 +1892,7 @@ mod tests {
     {
         let mut global = GlobalConfig::default();
         global.workflow.prompt_review_backends = Some(vec![
-            "codex(gpt-5.3-codex-xhigh)".to_owned(),
+            "codex(gpt-5.4-xhigh)".to_owned(),
             "claude(opus)".to_owned(),
         ]);
 
@@ -1938,7 +1926,7 @@ mod tests {
 
         let project = ProjectConfig {
             workflow: ProjectWorkflowOverrides {
-                prompt_review_backend: Some("codex(gpt-5.3-codex-xhigh)".to_owned()),
+                prompt_review_backend: Some("codex(gpt-5.4-xhigh)".to_owned()),
                 prompt_review_backends: Some(vec!["claude".to_owned(), "codex".to_owned()]),
                 ..ProjectWorkflowOverrides::default()
             },

--- a/src/daemon/refine.rs
+++ b/src/daemon/refine.rs
@@ -379,7 +379,7 @@ mod tests {
     #[test]
     fn create_backend_accepts_codex() {
         let config = GlobalConfig::default();
-        let result = create_backend("codex(gpt-5.3-codex-medium)", &config);
+        let result = create_backend("codex(gpt-5.4-medium)", &config);
         assert!(result.is_ok());
     }
 

--- a/src/prd/pipeline.rs
+++ b/src/prd/pipeline.rs
@@ -26,7 +26,7 @@ const MAX_SECTION_RETRIES: u8 = 2;
 pub struct PrdOptions {
     /// The product idea to generate a PRD for.
     pub idea: String,
-    /// The backend specification (e.g., "codex(gpt-5.3-codex)").
+    /// The backend specification (e.g., "codex(gpt-5.4)").
     pub backend_spec: String,
     /// Maximum number of question rounds.
     pub ask_max: u32,

--- a/src/prd/state.rs
+++ b/src/prd/state.rs
@@ -176,7 +176,7 @@ mod tests {
         let meta = PrdMeta {
             idea: "test idea".to_string(),
             idea_hash: "abc123".to_string(),
-            backend: "codex(gpt-5.3-codex)".to_string(),
+            backend: "codex(gpt-5.4)".to_string(),
             started_at: "2026-02-10T20:00:00Z".to_string(),
             completed_at: Some("2026-02-10T20:10:00Z".to_string()),
             stage_timings,

--- a/src/project/artifacts.rs
+++ b/src/project/artifacts.rs
@@ -536,7 +536,7 @@ mod tests {
                 artifact: "prompt-review",
                 file_name: "prompt-review.md",
                 project_id: "demo",
-                backend: "codex(gpt-5.3-codex-xhigh)",
+                backend: "codex(gpt-5.4-xhigh)",
                 role: "prompt_reviewer",
                 body: "# Prompt Review\n\n## Issues Found\n- mock\n\n## Refined Prompt\nThis is a sufficiently long refined prompt.",
             },
@@ -552,7 +552,7 @@ mod tests {
         let content = std::fs::read_to_string(path).expect("read artifact");
         assert!(content.contains("artifact: prompt-review"));
         assert!(content.contains("project: demo"));
-        assert!(content.contains("backend: codex(gpt-5.3-codex-xhigh)"));
+        assert!(content.contains("backend: codex(gpt-5.4-xhigh)"));
         assert!(content.contains("role: prompt_reviewer"));
         assert!(content.contains("created_at: "));
         assert!(

--- a/src/project/state.rs
+++ b/src/project/state.rs
@@ -744,7 +744,7 @@ mod tests {
         let mut store = SessionStore::default();
         store.upsert(SessionRecord {
             session_id: "sid-rt".to_owned(),
-            backend_spec: "codex(gpt-5.3-codex-high)".to_owned(),
+            backend_spec: "codex(gpt-5.4-high)".to_owned(),
             role: "reviewer".to_owned(),
             loop_number: 3,
             bootstrap_hash: "abcd1234".to_owned(),

--- a/src/validate/assertions.rs
+++ b/src/validate/assertions.rs
@@ -325,7 +325,7 @@ pub fn assert_json_array(value: &Value) -> &Vec<Value> {
 }
 
 /// Normalize a backend string by stripping model suffixes.
-/// For example: `"claude(sonnet-4)"` → `"claude"`, `"codex(gpt-5.3-codex)"` → `"codex"`.
+/// For example: `"claude(sonnet-4)"` → `"claude"`, `"codex(gpt-5.4)"` → `"codex"`.
 /// If the string has no parenthesized suffix, it is returned as-is (lowercased).
 pub fn normalize_backend(backend: &str) -> String {
     let s = backend.trim();

--- a/src/validate/tests_daemon.rs
+++ b/src/validate/tests_daemon.rs
@@ -632,7 +632,7 @@ fn config_merge_and_defaults(h: &RalphHarness) -> TestResult {
             "config",
             "set",
             "daemon.refinement_backend",
-            "codex(gpt-5.3-codex-medium)",
+            "codex(gpt-5.4-medium)",
             "--project",
             "daemon-config",
         ])
@@ -685,10 +685,7 @@ fn config_merge_and_defaults(h: &RalphHarness) -> TestResult {
         let refinement_backend_project = dh
             .ralph_ok(["config", "get", "daemon.refinement_backend"])
             .expect("config get daemon.refinement_backend should succeed");
-        assert_eq!(
-            refinement_backend_project.trim(),
-            "codex(gpt-5.3-codex-medium)"
-        );
+        assert_eq!(refinement_backend_project.trim(), "codex(gpt-5.4-medium)");
 
         let auto_rebase_enabled_project = dh
             .ralph_ok(["config", "get", "daemon.auto_rebase_enabled"])

--- a/src/validate/tests_prompt_review_panel.rs
+++ b/src/validate/tests_prompt_review_panel.rs
@@ -534,7 +534,7 @@ fn global_plural_explicit_default_wins_over_singular(h: &RalphHarness) -> TestRe
             "config",
             "set",
             "workflow.prompt_review_backends",
-            "[\"codex(gpt-5.3-codex-xhigh)\"]",
+            "[\"codex(gpt-5.4-xhigh)\"]",
             "--global",
         ])
         .expect("set global plural explicitly to default value");
@@ -549,7 +549,7 @@ fn global_plural_explicit_default_wins_over_singular(h: &RalphHarness) -> TestRe
         assert_json_field(
             &parsed,
             "workflow.prompt_review_backends",
-            &json!(["codex(gpt-5.3-codex-xhigh)"]),
+            &json!(["codex(gpt-5.4-xhigh)"]),
         );
     })
 }
@@ -569,7 +569,7 @@ fn project_singular_override_wins_over_global_plural(h: &RalphHarness) -> TestRe
             "config",
             "set",
             "workflow.prompt_review_backends",
-            "[\"codex(gpt-5.3-codex-xhigh)\",\"claude(opus)\"]",
+            "[\"codex(gpt-5.4-xhigh)\",\"claude(opus)\"]",
             "--global",
         ])
         .expect("set global plural");
@@ -633,7 +633,7 @@ fn singular_alias_rejects_optional_project_openrouter(h: &RalphHarness) -> TestR
                 "config",
                 "set",
                 "workflow.prompt_review_backend",
-                "?openrouter(gpt-5.3-codex-xhigh)",
+                "?openrouter(gpt-5.4-xhigh)",
                 "--project",
                 project_id,
             ])

--- a/src/workflow/orchestrator.rs
+++ b/src/workflow/orchestrator.rs
@@ -6557,9 +6557,9 @@ mod tests {
 
         assert!(registry.get("claude(opus)").is_some());
         assert!(registry.get("claude(sonnet)").is_some());
-        assert!(registry.get("codex(gpt-5.3-codex-xhigh)").is_some());
-        assert!(registry.get("codex(gpt-5.3-codex-high)").is_some());
-        assert!(registry.get("codex(gpt-5.3-codex-medium)").is_some());
+        assert!(registry.get("codex(gpt-5.4-xhigh)").is_some());
+        assert!(registry.get("codex(gpt-5.4-high)").is_some());
+        assert!(registry.get("codex(gpt-5.4-medium)").is_some());
     }
 
     #[test]
@@ -6574,8 +6574,8 @@ mod tests {
             .expect("preloading without role-models should succeed");
 
         assert!(registry.get("claude(opus)").is_none());
-        assert!(registry.get("codex(gpt-5.3-codex-xhigh)").is_none());
-        assert!(registry.get("openrouter(gpt-5.3-codex-xhigh)").is_none());
+        assert!(registry.get("codex(gpt-5.4-xhigh)").is_none());
+        assert!(registry.get("openrouter(gpt-5.4-xhigh)").is_none());
     }
 
     #[test]
@@ -8143,7 +8143,7 @@ mod tests {
         );
         let changed = super::compute_bootstrap_hash(
             "implementer",
-            "codex(gpt-5.3)",
+            "codex(gpt-5.4)",
             "phash",
             "spec",
             "template",

--- a/tests/backend.rs
+++ b/tests/backend.rs
@@ -68,10 +68,7 @@ fn test_backend_opposite() {
     assert_eq!(registry.opposite("claude").unwrap(), "codex");
     assert_eq!(registry.opposite("codex").unwrap(), "claude");
     assert_eq!(registry.opposite("claude(opus)").unwrap(), "codex");
-    assert_eq!(
-        registry.opposite("codex(gpt-5.3-codex-xhigh)").unwrap(),
-        "claude"
-    );
+    assert_eq!(registry.opposite("codex(gpt-5.4-xhigh)").unwrap(), "claude");
 }
 
 #[test]
@@ -148,7 +145,7 @@ fn resolve_backend_for_role_injects_model_when_configured() {
     );
     assert_eq!(
         registry.resolve_backend_for_role("codex", "planner"),
-        "codex(gpt-5.3-codex-xhigh)"
+        "codex(gpt-5.4-xhigh)"
     );
     assert_eq!(
         registry.resolve_backend_for_role("claude", "implementer"),
@@ -156,7 +153,7 @@ fn resolve_backend_for_role_injects_model_when_configured() {
     );
     assert_eq!(
         registry.resolve_backend_for_role("codex", "reviewer"),
-        "codex(gpt-5.3-codex-high)"
+        "codex(gpt-5.4-high)"
     );
     assert_eq!(
         registry.resolve_backend_for_role("claude", "final_reviewer"),
@@ -164,7 +161,7 @@ fn resolve_backend_for_role_injects_model_when_configured() {
     );
     assert_eq!(
         registry.resolve_backend_for_role("codex", "arbiter"),
-        "codex(gpt-5.3-codex-xhigh)"
+        "codex(gpt-5.4-xhigh)"
     );
     assert_eq!(
         registry.resolve_backend_for_role("claude", "completer"),
@@ -176,11 +173,11 @@ fn resolve_backend_for_role_injects_model_when_configured() {
     );
     assert_eq!(
         registry.resolve_backend_for_role("codex", "reformatter"),
-        "codex(gpt-5.3-codex-medium)"
+        "codex(gpt-5.4-medium)"
     );
     assert_eq!(
         registry.resolve_backend_for_role("codex", "qa"),
-        "codex(gpt-5.3-codex-high)"
+        "codex(gpt-5.4-high)"
     );
     assert_eq!(
         registry.resolve_backend_for_role("claude", "acceptance_qa"),
@@ -188,7 +185,7 @@ fn resolve_backend_for_role_injects_model_when_configured() {
     );
     assert_eq!(
         registry.resolve_backend_for_role("codex", "acceptance_qa"),
-        "codex(gpt-5.3-codex-xhigh)"
+        "codex(gpt-5.4-xhigh)"
     );
 }
 
@@ -268,17 +265,17 @@ fn test_assign_feature_backends() {
         .assign_feature_backends(1, "claude", &no_role_overrides())
         .unwrap();
     assert_eq!(backends.planner, "claude(opus)");
-    assert_eq!(backends.implementer, "codex(gpt-5.3-codex-high)");
+    assert_eq!(backends.implementer, "codex(gpt-5.4-high)");
     assert_eq!(backends.reviewer, "claude(opus)");
-    assert_eq!(backends.qa, "codex(gpt-5.3-codex-high)");
+    assert_eq!(backends.qa, "codex(gpt-5.4-high)");
 
     // Loop 2 (even): planner=codex, implementer=claude, reviewer=codex, qa=claude (opposite)
     let backends = registry
         .assign_feature_backends(2, "claude", &no_role_overrides())
         .unwrap();
-    assert_eq!(backends.planner, "codex(gpt-5.3-codex-xhigh)");
+    assert_eq!(backends.planner, "codex(gpt-5.4-xhigh)");
     assert_eq!(backends.implementer, "claude(opus)");
-    assert_eq!(backends.reviewer, "codex(gpt-5.3-codex-high)");
+    assert_eq!(backends.reviewer, "codex(gpt-5.4-high)");
     assert_eq!(backends.qa, "claude(opus)");
 }
 
@@ -298,7 +295,7 @@ fn test_assign_feature_backends_with_qa_override() {
         .assign_feature_backends(1, "claude", &role_overrides)
         .expect("qa override should resolve");
     assert_eq!(backends.planner, "claude(opus)");
-    assert_eq!(backends.qa, "codex(gpt-5.3-codex-high)");
+    assert_eq!(backends.qa, "codex(gpt-5.4-high)");
 }
 
 #[test]
@@ -331,15 +328,15 @@ fn test_assign_feature_backends_with_model_spec_start() {
         .assign_feature_backends(1, "claude(opus)", &no_role_overrides())
         .expect("loop 1 should resolve");
     assert_eq!(backends.planner, "claude(opus)");
-    assert_eq!(backends.implementer, "codex(gpt-5.3-codex-high)");
+    assert_eq!(backends.implementer, "codex(gpt-5.4-high)");
     assert_eq!(backends.reviewer, "claude(opus)");
 
     let backends = registry
         .assign_feature_backends(2, "claude(opus)", &no_role_overrides())
         .expect("loop 2 should resolve");
-    assert_eq!(backends.planner, "codex(gpt-5.3-codex-xhigh)");
+    assert_eq!(backends.planner, "codex(gpt-5.4-xhigh)");
     assert_eq!(backends.implementer, "claude(opus)");
-    assert_eq!(backends.reviewer, "codex(gpt-5.3-codex-high)");
+    assert_eq!(backends.reviewer, "codex(gpt-5.4-high)");
 }
 
 #[test]
@@ -382,7 +379,7 @@ fn test_assign_feature_backends_with_partial_role_overrides() {
         .expect("mixed feature backends should resolve");
     assert_eq!(backends.planner, "claude(opus)");
     assert_eq!(backends.implementer, "claude(opus)");
-    assert_eq!(backends.reviewer, "codex(gpt-5.3-codex-high)");
+    assert_eq!(backends.reviewer, "codex(gpt-5.4-high)");
 }
 
 #[test]
@@ -417,12 +414,12 @@ fn test_assign_completion_backends() {
         .assign_completion_backends(1, "claude", &no_role_overrides())
         .unwrap();
     assert_eq!(backends.planner, "claude(opus)");
-    assert_eq!(backends.completers[0], "codex(gpt-5.3-codex-xhigh)");
+    assert_eq!(backends.completers[0], "codex(gpt-5.4-xhigh)");
 
     let backends = registry
         .assign_completion_backends(2, "claude", &no_role_overrides())
         .unwrap();
-    assert_eq!(backends.planner, "codex(gpt-5.3-codex-xhigh)");
+    assert_eq!(backends.planner, "codex(gpt-5.4-xhigh)");
     assert_eq!(backends.completers[0], "claude(opus)");
 }
 
@@ -453,12 +450,12 @@ fn test_assign_completion_backends_with_model_spec_start() {
         .assign_completion_backends(1, "claude(opus)", &no_role_overrides())
         .expect("loop 1 should resolve");
     assert_eq!(backends.planner, "claude(opus)");
-    assert_eq!(backends.completers[0], "codex(gpt-5.3-codex-xhigh)");
+    assert_eq!(backends.completers[0], "codex(gpt-5.4-xhigh)");
 
     let backends = registry
         .assign_completion_backends(2, "claude(opus)", &no_role_overrides())
         .expect("loop 2 should resolve");
-    assert_eq!(backends.planner, "codex(gpt-5.3-codex-xhigh)");
+    assert_eq!(backends.planner, "codex(gpt-5.4-xhigh)");
     assert_eq!(backends.completers[0], "claude(opus)");
 }
 
@@ -467,7 +464,7 @@ fn test_assign_completion_backends_with_all_role_overrides() {
     let config = test_config();
     let registry = BackendRegistry::new(&config, tmux_disabled());
     let role_overrides = RoleOverrides {
-        planner: Some("codex(gpt-5.3-codex)".to_owned()),
+        planner: Some("codex(gpt-5.4)".to_owned()),
         implementer: None,
         reviewer: None,
         qa: None,
@@ -477,7 +474,7 @@ fn test_assign_completion_backends_with_all_role_overrides() {
     let backends = registry
         .assign_completion_backends(1, "claude", &role_overrides)
         .expect("overridden completion backends should resolve");
-    assert_eq!(backends.planner, "codex(gpt-5.3-codex)");
+    assert_eq!(backends.planner, "codex(gpt-5.4)");
     assert_eq!(backends.completers[0], "claude(opus)");
 }
 
@@ -514,36 +511,21 @@ fn test_backend_alternation_sequence() {
     // Loop 2: Codex planner, Claude implementer, Codex reviewer
     // etc.
     let expected = vec![
-        (
-            1,
-            "claude(opus)",
-            "codex(gpt-5.3-codex-high)",
-            "claude(opus)",
-        ),
+        (1, "claude(opus)", "codex(gpt-5.4-high)", "claude(opus)"),
         (
             2,
-            "codex(gpt-5.3-codex-xhigh)",
+            "codex(gpt-5.4-xhigh)",
             "claude(opus)",
-            "codex(gpt-5.3-codex-high)",
+            "codex(gpt-5.4-high)",
         ),
-        (
-            3,
-            "claude(opus)",
-            "codex(gpt-5.3-codex-high)",
-            "claude(opus)",
-        ),
+        (3, "claude(opus)", "codex(gpt-5.4-high)", "claude(opus)"),
         (
             4,
-            "codex(gpt-5.3-codex-xhigh)",
+            "codex(gpt-5.4-xhigh)",
             "claude(opus)",
-            "codex(gpt-5.3-codex-high)",
+            "codex(gpt-5.4-high)",
         ),
-        (
-            5,
-            "claude(opus)",
-            "codex(gpt-5.3-codex-high)",
-            "claude(opus)",
-        ),
+        (5, "claude(opus)", "codex(gpt-5.4-high)", "claude(opus)"),
     ];
 
     for (loop_num, exp_planner, exp_impl, exp_reviewer) in expected {
@@ -603,10 +585,10 @@ fn test_completion_alternation_sequence() {
     let registry = BackendRegistry::new(&config, tmux_disabled());
 
     let expected = vec![
-        (1, "claude(opus)", "codex(gpt-5.3-codex-xhigh)"),
-        (2, "codex(gpt-5.3-codex-xhigh)", "claude(opus)"),
-        (3, "claude(opus)", "codex(gpt-5.3-codex-xhigh)"),
-        (4, "codex(gpt-5.3-codex-xhigh)", "claude(opus)"),
+        (1, "claude(opus)", "codex(gpt-5.4-xhigh)"),
+        (2, "codex(gpt-5.4-xhigh)", "claude(opus)"),
+        (3, "claude(opus)", "codex(gpt-5.4-xhigh)"),
+        (4, "codex(gpt-5.4-xhigh)", "claude(opus)"),
     ];
 
     for (loop_num, exp_planner, exp_completer) in expected {
@@ -843,9 +825,9 @@ printf '%s\n' "$*"
 
     let mut registry = BackendRegistry::new(&config, tmux_disabled());
     let backend = registry
-        .get_or_create_for_spec("codex(gpt-5.3-codex-xhigh)")
+        .get_or_create_for_spec("codex(gpt-5.4-xhigh)")
         .expect("codex model backend should be created");
-    assert_eq!(backend.name(), "codex(gpt-5.3-codex-xhigh)");
+    assert_eq!(backend.name(), "codex(gpt-5.4-xhigh)");
 
     let output = backend
         .execute("hello")
@@ -858,11 +840,11 @@ printf '%s\n' "$*"
         "expected reasoning effort arg, got: {args}"
     );
     assert!(
-        args.contains("--model gpt-5.3-codex"),
+        args.contains("--model gpt-5.4"),
         "expected base model arg, got: {args}"
     );
     assert!(
-        !args.contains("--model gpt-5.3-codex-xhigh"),
+        !args.contains("--model gpt-5.4-xhigh"),
         "unexpected suffixed model arg: {args}"
     );
 }

--- a/tests/orchestrator.rs
+++ b/tests/orchestrator.rs
@@ -1070,21 +1070,12 @@ async fn two_loop_happy_path_with_separate_backends() {
     // --- 2. Backend alternation (with role-model injection from defaults) ---
     // Loop 1 (odd): planner=claude, implementer=codex, reviewer=claude
     assert_eq!(state.loops[0].backends.planner, "claude(opus)");
-    assert_eq!(
-        state.loops[0].backends.implementer,
-        "codex(gpt-5.3-codex-high)"
-    );
+    assert_eq!(state.loops[0].backends.implementer, "codex(gpt-5.4-high)");
     assert_eq!(state.loops[0].backends.reviewer, "claude(opus)");
     // Loop 2 (even): planner=codex, implementer=claude, reviewer=codex
-    assert_eq!(
-        state.loops[1].backends.planner,
-        "codex(gpt-5.3-codex-xhigh)"
-    );
+    assert_eq!(state.loops[1].backends.planner, "codex(gpt-5.4-xhigh)");
     assert_eq!(state.loops[1].backends.implementer, "claude(opus)");
-    assert_eq!(
-        state.loops[1].backends.reviewer,
-        "codex(gpt-5.3-codex-high)"
-    );
+    assert_eq!(state.loops[1].backends.reviewer, "codex(gpt-5.4-high)");
 
     // --- 3. Feature names ---
     assert_eq!(state.loops[0].feature_name, "Auth Module");
@@ -1572,7 +1563,7 @@ if [[ "$prompt" == *"CRITICAL: Your previous response could not be parsed."* ]];
   count=$((count + 1))
   echo "$count" > "$counter_file"
   args=" $* "
-  if [[ "$args" == *' -c model_reasoning_effort="medium" '* && "$args" == *" --model gpt-5.3-codex "* ]]; then
+  if [[ "$args" == *' -c model_reasoning_effort="medium" '* && "$args" == *" --model gpt-5.4 "* ]]; then
     model_counter_file="${COUNTER_DIR}/codex_reformat_model_count"
     model_count=0
     if [ -f "$model_counter_file" ]; then
@@ -1808,7 +1799,7 @@ async fn parse_retry_reformat_uses_opposite_backend() {
     assert_eq!(
         codex_model_count.trim(),
         "1",
-        "reformat retry should target codex(gpt-5.3-codex-medium), not bare codex"
+        "reformat retry should target codex(gpt-5.4-medium), not bare codex"
     );
 
     let claude_reformat_counter = counter_dir.join("claude_reformat_count");

--- a/tests/prd.rs
+++ b/tests/prd.rs
@@ -239,7 +239,7 @@ fn malformed_stage_output(label: &str) -> String {
 fn base_options(idea: &str, ask_max: u32) -> PrdOptions {
     PrdOptions {
         idea: idea.to_string(),
-        backend_spec: "codex(gpt-5.3-codex)".to_string(),
+        backend_spec: "codex(gpt-5.4)".to_string(),
         ask_max,
         resume: false,
         dry_run: false,

--- a/tests/state.rs
+++ b/tests/state.rs
@@ -584,9 +584,9 @@ fn test_qa_fields_serde_round_trip() {
         status: LoopStatus::InProgress,
         backends: FeatureLoopBackends {
             planner: "claude(opus)".to_owned(),
-            implementer: "codex(gpt-5.3-codex-high)".to_owned(),
+            implementer: "codex(gpt-5.4-high)".to_owned(),
             reviewer: "claude(opus)".to_owned(),
-            qa: "codex(gpt-5.3-codex-high)".to_owned(),
+            qa: "codex(gpt-5.4-high)".to_owned(),
         },
         artifacts: FeatureLoopArtifacts {
             spec: "loops/001-demo/spec.md".to_owned(),
@@ -615,7 +615,7 @@ fn test_qa_fields_serde_round_trip() {
         status: LoopStatus::InProgress,
         backends: CompletionLoopBackends::new(
             "claude(opus)".to_owned(),
-            vec!["codex(gpt-5.3-codex-xhigh)".to_owned()],
+            vec!["codex(gpt-5.4-xhigh)".to_owned()],
         ),
         artifacts: CompletionLoopArtifacts {
             termination_request: "loops/002-completion/termination-request.md".to_owned(),
@@ -636,7 +636,7 @@ fn test_qa_fields_serde_round_trip() {
     let json = serde_json::to_string(&state).expect("serialize state");
     let loaded: ProjectState = serde_json::from_str(&json).expect("deserialize state");
     assert_eq!(loaded.current_phase, Phase::QA);
-    assert_eq!(loaded.loops[0].backends.qa, "codex(gpt-5.3-codex-high)");
+    assert_eq!(loaded.loops[0].backends.qa, "codex(gpt-5.4-high)");
     assert_eq!(loaded.loops[0].artifacts.qa_results.len(), 1);
     assert_eq!(
         loaded.loops[0].artifacts.pending_qa_feedback.as_deref(),

--- a/tests/status_history.rs
+++ b/tests/status_history.rs
@@ -14,7 +14,7 @@ use ralph::project::state::{
 fn make_backends() -> FeatureLoopBackends {
     FeatureLoopBackends {
         planner: "claude(opus)".to_owned(),
-        implementer: "codex(gpt-5.3-codex-high)".to_owned(),
+        implementer: "codex(gpt-5.4-high)".to_owned(),
         reviewer: "claude(opus)".to_owned(),
         qa: "claude(opus)".to_owned(),
     }


### PR DESCRIPTION
## Summary
- Update all `gpt-5.3-codex` model references to `gpt-5.4` across source, tests, and docs
- Covers hardcoded defaults in `global.rs`, test fixtures, and documentation (26 files)
- Drops the `-codex` infix from model names (new naming convention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)