### PR TITLE
Remove inline git diff from agent prompts

### DIFF
--- a/src/prompts/templates.rs
+++ b/src/prompts/templates.rs
@@ -167,7 +167,7 @@ If this is a review-response pass, output `<TS>-impl-response-III.md` in this fo
 {{master_prompt}}
 
 ## Current Diff
-{{current_diff}}
+To see the current implementation changes, run `git diff` in the repository root. You can also use `git diff --stat` for an overview, then read specific files as needed.
 "#
 }
 
@@ -247,7 +247,7 @@ OR:
 {{latest_implementation_response}}
 
 ## Implementation Diff
-{{current_diff}}
+To see the current implementation changes, run `git diff` in the repository root. You can also use `git diff --stat` for an overview, then read specific files as needed.
 
 ### Review History (prior iterations)
 {{review_history}}
@@ -388,7 +388,7 @@ If any checks fail:
 {{implementation_notes}}
 
 ## Implementation Diff
-{{current_diff}}
+To see the current implementation changes, run `git diff` in the repository root. You can also use `git diff --stat` for an overview, then read specific files as needed.
 
 ## Prior QA History
 {{prior_qa_history}}

--- a/src/workflow/orchestrator.rs
+++ b/src/workflow/orchestrator.rs
@@ -22,8 +22,7 @@ use crate::git::branch::{branch_exists, checkout_branch, merge_base_branch, reso
 use crate::git::commit::{
     changed_paths_excluding_prefixes, commit_and_push_initial_prompt,
     commit_and_push_phase_transition, commit_feature_loop, reset_and_clean_working_tree, rev_parse,
-    stage_implementation_changes, working_tree_diff_excluding_orchestration_state,
-    ORCHESTRATION_STATE_PATH_PREFIX,
+    stage_implementation_changes, ORCHESTRATION_STATE_PATH_PREFIX,
 };
 use crate::git::is_git_repo;
 use crate::output_log::LogWriter;
@@ -864,7 +863,6 @@ impl Orchestrator {
                         registry.get_or_create_for_role(&implementer_backend_name, "implementer")?;
 
                     let spec_content = read_project_relative_file(&project_dir, &spec_rel)?;
-                    let git_diff = current_git_diff(&self.workspace.root)?;
                     let iteration = state.phase_iteration;
 
                     if impl_notes_rel.is_none() {
@@ -909,7 +907,6 @@ impl Orchestrator {
                             implementer_backend.name(),
                             &planner_backend,
                             &spec_content,
-                            &git_diff,
                             None,
                             None,
                             &project_dir,
@@ -1067,7 +1064,6 @@ impl Orchestrator {
                             implementer_backend.name(),
                             &planner_backend,
                             &spec_content,
-                            &git_diff,
                             Some(iteration),
                             Some(&qa_feedback_content),
                             &project_dir,
@@ -1241,7 +1237,6 @@ impl Orchestrator {
                             implementer_backend.name(),
                             &planner_backend,
                             &spec_content,
-                            &git_diff,
                             Some(iteration),
                             Some(&labeled_feedback),
                             &project_dir,
@@ -1397,7 +1392,6 @@ impl Orchestrator {
                             implementer_backend.name(),
                             &planner_backend,
                             &spec_content,
-                            &git_diff,
                             Some(iteration),
                             Some(&feedback_content),
                             &project_dir,
@@ -1596,7 +1590,6 @@ impl Orchestrator {
                     })?;
                     let impl_notes_content =
                         read_project_relative_file(&project_dir, &impl_notes_rel)?;
-                    let git_diff = current_git_diff(&self.workspace.root)?;
 
                     // Session reuse: resolve session for QA (before history collection
                     // so we can pass actual session-reuse state to the history builder)
@@ -1644,7 +1637,6 @@ impl Orchestrator {
                         &planner_backend_name,
                         &spec_content,
                         &impl_notes_content,
-                        &git_diff,
                         &qa_history,
                     )?;
 
@@ -1854,7 +1846,6 @@ impl Orchestrator {
                         })?;
                         let impl_notes_content =
                             read_project_relative_file(&project_dir, &impl_notes_rel)?;
-                        let git_diff = current_git_diff(&self.workspace.root)?;
 
                         let previous_iteration = state.phase_iteration.saturating_sub(1);
                         let impl_response_content = if previous_iteration > 0 {
@@ -1912,7 +1903,6 @@ impl Orchestrator {
                             &spec_content,
                             &impl_notes_content,
                             impl_response_content.as_deref(),
-                            &git_diff,
                             &project_dir,
                             reviewer_session_id.is_some(),
                         )?;
@@ -3484,7 +3474,6 @@ fn build_implementer_prompt(
     backend: &str,
     opposite_backend: &str,
     spec_content: &str,
-    git_diff: &str,
     iteration: Option<u32>,
     review_feedback: Option<&str>,
     project_dir: &Path,
@@ -3510,11 +3499,9 @@ fn build_implementer_prompt(
     vars.insert("master_prompt".to_owned(), prompt_content.to_owned());
     vars.insert("spec_content".to_owned(), spec_content.to_owned());
     vars.insert("feature_spec".to_owned(), spec_content.to_owned());
-    vars.insert("git_diff".to_owned(), git_diff.to_owned());
-    vars.insert(
-        "current_diff".to_owned(),
-        format!("```diff\n{git_diff}\n```"),
-    );
+    let diff_instruction = "To see the current implementation changes, run `git diff` in the repository root. You can also use `git diff --stat` for an overview, then read specific files as needed.";
+    vars.insert("git_diff".to_owned(), diff_instruction.to_owned());
+    vars.insert("current_diff".to_owned(), diff_instruction.to_owned());
     let review_feedback_text = review_feedback.unwrap_or("(none)");
     vars.insert(
         "review_feedback".to_owned(),
@@ -3560,13 +3547,12 @@ fn build_implementer_prompt(
         "## Feature Spec",
         spec_content,
     );
-    let current_diff_block = format!("```diff\n{git_diff}\n```");
     append_section_if_missing(
         &mut prompt,
         &template_source,
         &["current_diff", "git_diff"],
         "## Current Diff",
-        &current_diff_block,
+        diff_instruction,
     );
     append_section_if_missing(
         &mut prompt,
@@ -3590,7 +3576,6 @@ fn build_reviewer_prompt(
     spec_content: &str,
     impl_notes_content: &str,
     impl_response_content: Option<&str>,
-    git_diff: &str,
     project_dir: &Path,
     session_reused_this_call: bool,
 ) -> Result<String> {
@@ -3619,11 +3604,9 @@ fn build_reviewer_prompt(
         "implementation_notes".to_owned(),
         impl_notes_content.to_owned(),
     );
-    vars.insert("git_diff".to_owned(), git_diff.to_owned());
-    vars.insert(
-        "current_diff".to_owned(),
-        format!("```diff\n{git_diff}\n```"),
-    );
+    let diff_instruction = "To see the current implementation changes, run `git diff` in the repository root. You can also use `git diff --stat` for an overview, then read specific files as needed.";
+    vars.insert("git_diff".to_owned(), diff_instruction.to_owned());
+    vars.insert("current_diff".to_owned(), diff_instruction.to_owned());
     let latest_impl_response = impl_response_content.unwrap_or("(none)");
     vars.insert(
         "latest_implementation_response".to_owned(),
@@ -3683,13 +3666,12 @@ fn build_reviewer_prompt(
         "## Latest Implementation Response",
         latest_impl_response,
     );
-    let current_diff_block = format!("```diff\n{git_diff}\n```");
     append_section_if_missing(
         &mut prompt,
         &template_source,
         &["current_diff", "git_diff"],
         "## Current Diff",
-        &current_diff_block,
+        diff_instruction,
     );
     Ok(prompt)
 }
@@ -5378,7 +5360,6 @@ fn build_qa_prompt(
     opposite_backend: &str,
     spec_content: &str,
     impl_notes_content: &str,
-    git_diff: &str,
     qa_history: &str,
 ) -> Result<String> {
     let template_source = load_template_source(&effective.templates.qa, default_qa_template());
@@ -5405,11 +5386,9 @@ fn build_qa_prompt(
         "implementation_notes".to_owned(),
         impl_notes_content.to_owned(),
     );
-    vars.insert("git_diff".to_owned(), git_diff.to_owned());
-    vars.insert(
-        "current_diff".to_owned(),
-        format!("```diff\n{git_diff}\n```"),
-    );
+    let diff_instruction = "To see the current implementation changes, run `git diff` in the repository root. You can also use `git diff --stat` for an overview, then read specific files as needed.";
+    vars.insert("git_diff".to_owned(), diff_instruction.to_owned());
+    vars.insert("current_diff".to_owned(), diff_instruction.to_owned());
     let qa_history_text = if qa_history.is_empty() {
         "(none)"
     } else {
@@ -5450,13 +5429,12 @@ fn build_qa_prompt(
         "## Implementation Notes",
         impl_notes_content,
     );
-    let current_diff_block = format!("```diff\n{git_diff}\n```");
     append_section_if_missing(
         &mut prompt,
         &template_source,
         &["current_diff", "git_diff"],
         "## Current Diff",
-        &current_diff_block,
+        diff_instruction,
     );
     append_section_if_missing(
         &mut prompt,
@@ -5637,17 +5615,6 @@ fn ensure_clean_start_for_new_loop(workspace_root: &Path) -> Result<()> {
     Err(RalphError::Validation(format!(
         "cannot start a new loop with uncommitted changes outside `.ralph/`.\ncommit/stash/discard those paths first:\n{sample}{remainder}"
     )))
-}
-
-fn current_git_diff(workspace_root: &Path) -> Result<String> {
-    let Some(repo_root) = workspace_root.parent() else {
-        return Ok(String::new());
-    };
-    if !is_git_repo(repo_root) {
-        return Ok(String::new());
-    }
-
-    working_tree_diff_excluding_orchestration_state(repo_root)
 }
 
 fn stage_changes_for_review(workspace_root: &Path) -> Result<()> {
@@ -6557,9 +6524,9 @@ mod tests {
 
         assert!(registry.get("claude(opus)").is_some());
         assert!(registry.get("claude(sonnet)").is_some());
-        assert!(registry.get("codex(gpt-5.3-codex-xhigh)").is_some());
-        assert!(registry.get("codex(gpt-5.3-codex-high)").is_some());
-        assert!(registry.get("codex(gpt-5.3-codex-medium)").is_some());
+        assert!(registry.get("codex(gpt-5.4-xhigh)").is_some());
+        assert!(registry.get("codex(gpt-5.4-high)").is_some());
+        assert!(registry.get("codex(gpt-5.4-medium)").is_some());
     }
 
     #[test]
@@ -6574,8 +6541,8 @@ mod tests {
             .expect("preloading without role-models should succeed");
 
         assert!(registry.get("claude(opus)").is_none());
-        assert!(registry.get("codex(gpt-5.3-codex-xhigh)").is_none());
-        assert!(registry.get("openrouter(gpt-5.3-codex-xhigh)").is_none());
+        assert!(registry.get("codex(gpt-5.4-xhigh)").is_none());
+        assert!(registry.get("openrouter(gpt-5.4-xhigh)").is_none());
     }
 
     #[test]
@@ -8143,7 +8110,7 @@ mod tests {
         );
         let changed = super::compute_bootstrap_hash(
             "implementer",
-            "codex(gpt-5.3)",
+            "codex(gpt-5.4)",
             "phash",
             "spec",
             "template",

--- a/src/workflow/quick_dev_orchestrator.rs
+++ b/src/workflow/quick_dev_orchestrator.rs
@@ -12,8 +12,7 @@ use crate::backend::{parse_backend_spec, Backend, BackendRegistry, BackendRegist
 use crate::config::{resolve_effective_config, EffectiveConfig, RunWorkflowOverrides};
 use crate::error::RalphError;
 use crate::git::commit::{
-    changed_paths_excluding_prefixes, commit_and_push_phase_transition,
-    remove_stray_impl_artifacts, working_tree_diff_excluding_orchestration_state,
+    changed_paths_excluding_prefixes, commit_and_push_phase_transition, remove_stray_impl_artifacts,
 };
 use crate::git::is_git_repo;
 use crate::output_log::LogWriter;
@@ -339,14 +338,12 @@ impl QuickDevOrchestrator {
                 QuickDevPhase::PlanAndImplement => {
                     info!(loop_number, "quick-dev: PlanAndImplement phase");
 
-                    let git_diff = current_git_diff(&self.workspace.root)?;
                     let final_review_handoff =
                         pending_final_review_handoff.take().unwrap_or_default();
                     let mut prompt = build_plan_implement_prompt(
                         effective,
                         &prompt_content,
                         &spec_content,
-                        &git_diff,
                         &final_review_handoff,
                     )?;
 
@@ -503,13 +500,8 @@ impl QuickDevOrchestrator {
                         review_iteration, "quick-dev: CodexReview phase"
                     );
 
-                    let git_diff = current_git_diff(&self.workspace.root)?;
-                    let prompt = build_codex_review_prompt(
-                        effective,
-                        &prompt_content,
-                        &spec_content,
-                        &git_diff,
-                    )?;
+                    let prompt =
+                        build_codex_review_prompt(effective, &prompt_content, &spec_content)?;
 
                     let rev_backend = registry.get_or_create_for_role(reviewer_spec, "reviewer")?;
 
@@ -662,13 +654,11 @@ impl QuickDevOrchestrator {
                 QuickDevPhase::ApplyFixes => {
                     info!(loop_number, review_iteration, "quick-dev: ApplyFixes phase");
 
-                    let git_diff = current_git_diff(&self.workspace.root)?;
                     let prompt = build_apply_fixes_prompt(
                         effective,
                         &prompt_content,
                         &spec_content,
                         &last_review_feedback,
-                        &git_diff,
                     )?;
 
                     let impl_backend =
@@ -1454,20 +1444,6 @@ fn save_state_to_disk(state: &ProjectState, project_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// Git helpers
-// ---------------------------------------------------------------------------
-
-fn current_git_diff(workspace_root: &Path) -> Result<String> {
-    let Some(repo_root) = workspace_root.parent() else {
-        return Ok(String::new());
-    };
-    if !is_git_repo(repo_root) {
-        return Ok(String::new());
-    }
-    working_tree_diff_excluding_orchestration_state(repo_root)
-}
-
 #[allow(clippy::too_many_arguments)]
 fn checkpoint_if_enabled(
     workspace: &Workspace,
@@ -1527,7 +1503,6 @@ fn build_plan_implement_prompt(
     effective: &EffectiveConfig,
     prompt_content: &str,
     spec_content: &str,
-    git_diff: &str,
     final_review_handoff: &str,
 ) -> Result<String> {
     let mut vars = BTreeMap::new();
@@ -1537,7 +1512,8 @@ fn build_plan_implement_prompt(
     );
     vars.insert("feature_spec".to_owned(), spec_content.to_owned());
     vars.insert("master_prompt".to_owned(), prompt_content.to_owned());
-    vars.insert("current_diff".to_owned(), git_diff.to_owned());
+    let diff_instruction = "To see the current implementation changes, run `git diff` in the repository root. You can also use `git diff --stat` for an overview, then read specific files as needed.";
+    vars.insert("current_diff".to_owned(), diff_instruction.to_owned());
     vars.insert(
         "final_review_handoff".to_owned(),
         final_review_handoff.to_owned(),
@@ -1549,7 +1525,6 @@ fn build_codex_review_prompt(
     effective: &EffectiveConfig,
     prompt_content: &str,
     spec_content: &str,
-    git_diff: &str,
 ) -> Result<String> {
     let mut vars = BTreeMap::new();
     vars.insert(
@@ -1558,7 +1533,8 @@ fn build_codex_review_prompt(
     );
     vars.insert("feature_spec".to_owned(), spec_content.to_owned());
     vars.insert("master_prompt".to_owned(), prompt_content.to_owned());
-    vars.insert("current_diff".to_owned(), git_diff.to_owned());
+    let diff_instruction = "To see the current implementation changes, run `git diff` in the repository root. You can also use `git diff --stat` for an overview, then read specific files as needed.";
+    vars.insert("current_diff".to_owned(), diff_instruction.to_owned());
     build_quick_dev_codex_review_prompt(&effective.templates.quick_dev_codex_review, &vars)
 }
 
@@ -1567,7 +1543,6 @@ fn build_apply_fixes_prompt(
     prompt_content: &str,
     spec_content: &str,
     review_feedback: &str,
-    git_diff: &str,
 ) -> Result<String> {
     let mut vars = BTreeMap::new();
     vars.insert(
@@ -1577,7 +1552,8 @@ fn build_apply_fixes_prompt(
     vars.insert("feature_spec".to_owned(), spec_content.to_owned());
     vars.insert("review_feedback".to_owned(), review_feedback.to_owned());
     vars.insert("master_prompt".to_owned(), prompt_content.to_owned());
-    vars.insert("current_diff".to_owned(), git_diff.to_owned());
+    let diff_instruction = "To see the current implementation changes, run `git diff` in the repository root. You can also use `git diff --stat` for an overview, then read specific files as needed.";
+    vars.insert("current_diff".to_owned(), diff_instruction.to_owned());
     build_quick_dev_apply_fixes_prompt(&effective.templates.quick_dev_apply_fixes, &vars)
 }
 

--- a/tests/templates.rs
+++ b/tests/templates.rs
@@ -112,7 +112,7 @@ fn test_default_implementer_template_contains_required_sections() {
     assert!(template.contains("{{review_feedback}}"));
     assert!(template.contains("{{review_history}}"));
     assert!(template.contains("{{master_prompt}}"));
-    assert!(template.contains("{{current_diff}}"));
+    assert!(template.contains("git diff"));
 }
 
 #[test]
@@ -133,7 +133,7 @@ fn test_default_reviewer_template_contains_required_sections() {
     assert!(template.contains("{{master_prompt}}"));
     assert!(template.contains("{{feature_spec}}"));
     assert!(template.contains("{{implementation_notes}}"));
-    assert!(template.contains("{{current_diff}}"));
+    assert!(template.contains("git diff"));
     assert!(template.contains("{{review_history}}"));
 }
 


### PR DESCRIPTION
## Summary
- Remove the inline `git diff` from implementer, reviewer, and QA prompts to prevent context window overflow on large codebases
- Agents now receive an instruction to run `git diff` themselves, which they can do incrementally via their tool use
- Removes `current_git_diff()` helper functions and the `git_diff` parameter from all prompt builder functions in both `orchestrator.rs` and `quick_dev_orchestrator.rs`

## Motivation
On larger projects (8+ loops), the accumulated git diff was large enough to blow the 200K context window, causing `invalid_request` / "Prompt is too long" errors mid-implementation. Since agents already have shell access, they can run `git diff` on demand and inspect specific files as needed, which is both more token-efficient and gives them control over what they read.

## Test plan
- [x] `cargo check` clean (no warnings)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — all 436 tests pass (1 pre-existing unrelated failure in daemon github tests)
- [x] `nix build` — static binary builds and passes linkage verification
- [x] Template tests updated to assert `git diff` instruction instead of `{{current_diff}}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)