### PR TITLE
fix(daemon): skip daemon-generated comments in PR review polling

### DIFF
--- a/src/daemon/pr_review.rs
+++ b/src/daemon/pr_review.rs
@@ -664,6 +664,12 @@ pub async fn poll_pr_reviews(
                 continue;
             }
 
+            // Skip daemon-generated comments (status updates, rebase
+            // notifications, etc.) which all start with an HTML marker.
+            if comment.body.trim_start().starts_with("<!-- ralph:") {
+                continue;
+            }
+
             // Dedup check.
             let key = comment.dedup_key();
             if state.processed_keys.contains(&key) {
@@ -905,12 +911,22 @@ mod tests {
                 line: None,
                 created_at: "2024-01-01T00:00:00Z".to_string(),
             },
+            PrReviewComment {
+                id: 4,
+                endpoint: CommentEndpoint::IssueComment,
+                author: "alice".to_string(),
+                body: "<!-- ralph:rebase:task-1:failed:abc123 -->\nAuto-rebase failed".to_string(),
+                path: None,
+                line: None,
+                created_at: "2024-01-01T00:00:00Z".to_string(),
+            },
         ];
 
         let filtered: Vec<_> = comments
             .iter()
             .filter(|c| whitelist.iter().any(|w| w.eq_ignore_ascii_case(&c.author)))
             .filter(|c| !c.body.trim().is_empty())
+            .filter(|c| !c.body.trim_start().starts_with("<!-- ralph:"))
             .collect();
 
         assert_eq!(filtered.len(), 2);


### PR DESCRIPTION
## Summary
- Skip comments starting with `<!-- ralph:` in the PR review poller — these are daemon-generated status comments (rebase failures, artifact posts, etc.) that should not trigger amendments
- Discovered during e2e testing: after removing the self-comment author filter (#212), the daemon's own rebase failure notification was being picked up as an amendment

## Test plan
- [x] All 28 `daemon::pr_review` unit tests pass (including updated `whitelist_filtering` test covering the marker filter)
- [x] All 436 nix integration tests pass
- [x] `cargo clippy` zero warnings