### PR TITLE
fix(daemon): use npx for oracle with configurable command

### DIFF
--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -185,6 +185,7 @@ fn execute_show(workspace: &Workspace, scope: &ConfigScope) -> Result<()> {
                     "oracle_review_authors": effective.daemon.oracle_review_authors,
                     "oracle_review_max_per_cycle": effective.daemon.oracle_review_max_per_cycle,
                     "oracle_review_cooldown_secs": effective.daemon.oracle_review_cooldown_secs,
+                    "oracle_review_command": effective.daemon.oracle_review_command,
                     "oracle_review_args": effective.daemon.oracle_review_args,
                 },
                 "templates": {
@@ -300,6 +301,7 @@ fn execute_get(workspace: &Workspace, scope: &ConfigScope, key: &str) -> Result<
                     "oracle_review_authors": effective.daemon.oracle_review_authors,
                     "oracle_review_max_per_cycle": effective.daemon.oracle_review_max_per_cycle,
                     "oracle_review_cooldown_secs": effective.daemon.oracle_review_cooldown_secs,
+                    "oracle_review_command": effective.daemon.oracle_review_command,
                     "oracle_review_args": effective.daemon.oracle_review_args,
                 },
                 "templates": {

--- a/src/cli/daemon.rs
+++ b/src/cli/daemon.rs
@@ -260,6 +260,7 @@ async fn execute_start(args: DaemonStartArgs) -> Result<()> {
             oracle_review_authors: daemon_cfg.oracle_review_authors.clone(),
             oracle_review_max_per_cycle: daemon_cfg.oracle_review_max_per_cycle,
             oracle_review_cooldown_secs: daemon_cfg.oracle_review_cooldown_secs,
+            oracle_review_command: daemon_cfg.oracle_review_command.clone(),
             oracle_review_args: daemon_cfg.oracle_review_args.clone(),
             git_bin,
             gh_bin,

--- a/src/config/global.rs
+++ b/src/config/global.rs
@@ -97,6 +97,8 @@ pub struct WorkspaceConfig {
     pub daemon_oracle_review_max_per_cycle: u32,
     #[serde(default = "default_daemon_oracle_review_cooldown_secs")]
     pub daemon_oracle_review_cooldown_secs: u64,
+    #[serde(default = "default_daemon_oracle_review_command")]
+    pub daemon_oracle_review_command: String,
     #[serde(default)]
     pub daemon_oracle_review_args: Vec<String>,
     /// Maximum backend timeout retries per invocation (default: 3, max: 10).
@@ -554,6 +556,7 @@ impl Default for WorkspaceConfig {
             daemon_oracle_review_authors: Vec::new(),
             daemon_oracle_review_max_per_cycle: default_daemon_oracle_review_max_per_cycle(),
             daemon_oracle_review_cooldown_secs: default_daemon_oracle_review_cooldown_secs(),
+            daemon_oracle_review_command: default_daemon_oracle_review_command(),
             daemon_oracle_review_args: Vec::new(),
             daemon_max_backend_retries: None,
             daemon_pr_review_whitelist: Vec::new(),
@@ -977,6 +980,10 @@ fn default_daemon_oracle_review_timeout_secs() -> u64 {
 
 fn default_daemon_oracle_review_max_per_cycle() -> u32 {
     3
+}
+
+fn default_daemon_oracle_review_command() -> String {
+    "npx".to_owned()
 }
 
 fn default_daemon_oracle_review_cooldown_secs() -> u64 {
@@ -1476,6 +1483,9 @@ pub(crate) fn set_global_config_value(
         }
         "workspace.daemon_oracle_review_cooldown_secs" => {
             config.workspace.daemon_oracle_review_cooldown_secs = cfg_parse_u64(raw_value, key)?;
+        }
+        "workspace.daemon_oracle_review_command" => {
+            config.workspace.daemon_oracle_review_command = raw_value.to_owned();
         }
         "workspace.daemon_oracle_review_args" => {
             config.workspace.daemon_oracle_review_args = cfg_parse_string_list(raw_value)?;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -127,6 +127,7 @@ pub struct EffectiveDaemonConfig {
     pub oracle_review_authors: Vec<String>,
     pub oracle_review_max_per_cycle: u32,
     pub oracle_review_cooldown_secs: u64,
+    pub oracle_review_command: String,
     pub oracle_review_args: Vec<String>,
     /// Maximum number of backend timeout retries per invocation.
     pub max_backend_retries: Option<u8>,
@@ -533,6 +534,7 @@ pub fn resolve_daemon_config(
         oracle_review_authors: global.workspace.daemon_oracle_review_authors.clone(),
         oracle_review_max_per_cycle: global.workspace.daemon_oracle_review_max_per_cycle,
         oracle_review_cooldown_secs: global.workspace.daemon_oracle_review_cooldown_secs,
+        oracle_review_command: global.workspace.daemon_oracle_review_command.clone(),
         oracle_review_args: global.workspace.daemon_oracle_review_args.clone(),
         max_backend_retries: global.workspace.daemon_max_backend_retries,
         pr_review_whitelist: global.workspace.daemon_pr_review_whitelist.clone(),

--- a/src/daemon/oracle_review.rs
+++ b/src/daemon/oracle_review.rs
@@ -239,6 +239,7 @@ pub async fn oracle_review_phase(config: &DaemonRuntimeConfig) -> Result<()> {
             &pr.head_sha,
             diff,
             config.oracle_review_timeout_secs,
+            config.oracle_review_command.clone(),
             config.oracle_review_args.clone(),
         )
         .await
@@ -363,6 +364,7 @@ async fn invoke_oracle(
     head_sha: &str,
     diff: String,
     timeout_secs: u64,
+    oracle_command: String,
     extra_args: Vec<String>,
 ) -> Result<String> {
     let workspace_root = workspace_root.to_path_buf();
@@ -388,7 +390,14 @@ async fn invoke_oracle(
         })?;
 
         let result = (|| -> Result<String> {
-            let mut command = std::process::Command::new("oracle");
+            let is_npx = std::path::Path::new(&oracle_command)
+                .file_name()
+                .and_then(|f| f.to_str())
+                .is_some_and(|name| name == "npx");
+            let mut command = std::process::Command::new(&oracle_command);
+            if is_npx {
+                command.arg("-y").arg("@steipete/oracle");
+            }
             for arg in &extra_args {
                 command.arg(arg);
             }

--- a/src/daemon/runtime.rs
+++ b/src/daemon/runtime.rs
@@ -87,7 +87,9 @@ pub struct DaemonRuntimeConfig {
     /// Minimum seconds of inactivity (since last PR update) before Oracle reviews a PR.
     /// Prevents reviewing PRs that are still being actively amended/rebased.
     pub oracle_review_cooldown_secs: u64,
-    /// Extra CLI arguments passed to the `oracle` command (e.g. `["--engine", "browser", "--browser-manual-login"]`).
+    /// Command to invoke for oracle reviews (default: `"npx"`, which auto-prepends `-y @steipete/oracle`).
+    pub oracle_review_command: String,
+    /// Extra CLI arguments passed to the oracle command.
     pub oracle_review_args: Vec<String>,
     /// Executable used for git invocations in interactive PRD.
     pub git_bin: String,
@@ -4820,6 +4822,7 @@ mod tests {
             oracle_review_authors: vec![],
             oracle_review_max_per_cycle: 3,
             oracle_review_cooldown_secs: 0,
+            oracle_review_command: "oracle".to_owned(),
             oracle_review_args: vec![],
             git_bin: "git".to_owned(),
             gh_bin: "gh".to_owned(),
@@ -4917,6 +4920,7 @@ mod tests {
             oracle_review_authors: vec![],
             oracle_review_max_per_cycle: 3,
             oracle_review_cooldown_secs: 0,
+            oracle_review_command: "oracle".to_owned(),
             oracle_review_args: vec![],
             git_bin: "git".to_owned(),
             gh_bin: "gh".to_owned(),

--- a/src/validate/tests_daemon_oracle_review.rs
+++ b/src/validate/tests_daemon_oracle_review.rs
@@ -1551,6 +1551,16 @@ fn enable_oracle_review(dh: &RalphHarness) {
         "--global",
     ])
     .expect("enable oracle review");
+    // Use bare `oracle` command so the mock script in PATH is invoked
+    // instead of the default `npx -y @steipete/oracle`.
+    dh.ralph_ok([
+        "config",
+        "set",
+        "workspace.daemon_oracle_review_command",
+        "oracle",
+        "--global",
+    ])
+    .expect("set oracle command");
 }
 
 fn run_daemon_once(

--- a/src/validate/tests_pr_lifecycle.rs
+++ b/src/validate/tests_pr_lifecycle.rs
@@ -427,6 +427,7 @@ fn daemon_config(repo_root: &Path) -> crate::daemon::runtime::DaemonRuntimeConfi
         oracle_review_authors: vec![],
         oracle_review_max_per_cycle: 3,
         oracle_review_cooldown_secs: 0,
+        oracle_review_command: "oracle".to_owned(),
         oracle_review_args: vec![],
         git_bin: "git".to_owned(),
         gh_bin: "gh".to_owned(),

--- a/src/workflow/quick_dev_orchestrator.rs
+++ b/src/workflow/quick_dev_orchestrator.rs
@@ -2182,6 +2182,7 @@ mod tests {
                 oracle_review_authors: vec![],
                 oracle_review_max_per_cycle: 3,
                 oracle_review_cooldown_secs: 0,
+                oracle_review_command: "oracle".to_owned(),
                 oracle_review_args: vec![],
                 max_backend_retries: None,
                 pr_review_whitelist: vec![],


### PR DESCRIPTION
## Summary
- Default oracle command is now `npx` which auto-prepends `-y @steipete/oracle`, ensuring the latest version
- New config `daemon_oracle_review_command` allows overriding (e.g. `"oracle"` for global installs)
- New config `daemon_oracle_review_args` for extra CLI flags (e.g. `["--engine", "browser", "--browser-manual-login"]`)
- Validate tests set `daemon_oracle_review_command = "oracle"` so mock scripts continue to work
- Full config CLI wiring: `set_global_config_value`, `config show`, `config get`

## Test plan
- [x] All nix tests pass (462 including oracle review suite with mock override)
- [x] `cargo clippy -- -D warnings` clean