### PR TITLE
docs: mark project deprecated in favor of rb-lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+> [!WARNING]
+> **Deprecated — superseded by [rb-lite](https://github.com/douglaz/rb-lite).**
+>
+> This project (`ralph` / `multibackend-orchestration`) is no longer maintained.
+> Its role has been replaced by **rb-lite**, a smaller Bash CLI that drives an
+> implement → review loop with `codex` and `claude` as the implementer and
+> reviewer panel. Please use rb-lite for new work; the code here is kept for
+> historical reference only.
+
 # ralph
 
 `ralph` is a multi-backend orchestration tool for structured AI development loops.


### PR DESCRIPTION
## Summary

Adds a prominent deprecation banner to the top of `README.md`. This project (`ralph` / `multibackend-orchestration`) is no longer maintained and has been superseded by [rb-lite](https://github.com/douglaz/rb-lite).

## Changes

- Add a `> [!WARNING]` deprecation notice at the top of `README.md` pointing users to rb-lite for new work.

## Notes

- Documentation-only change; no code paths affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a deprecation notice indicating the project is no longer actively maintained. Users are directed to use the recommended alternative for new development, while this repository remains available as historical reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->